### PR TITLE
Feature find rooms

### DIFF
--- a/compose.integration.yml
+++ b/compose.integration.yml
@@ -16,6 +16,16 @@ services:
         condition: service_healthy
     environment:
       JWT_PUBLIC_KEY_PATH: /app/keys/public_key.pem
+      ROOM_DB_HOST: room-db
+      ROOM_DB_PORT: 5432
+      ROOM_DB_NAME: bookem_roomdb_test
+      ROOM_DB_USER: bookem_roomdb_user
+      ROOM_DB_PASSWORD: testpass
+      USER_DB_HOST: user-db
+      USER_DB_PORT: 5432
+      USER_DB_NAME: bookem_userdb_test
+      USER_DB_USER: bookem_userdb_user
+      USER_DB_PASSWORD: testpass
     volumes:
       - go-mod-cache:/go/pkg/mod
       - ${ROOM_SERVICE_PATH}/keys/public_key.pem:/app/keys/public_key.pem:ro

--- a/src/internal/dto.go
+++ b/src/internal/dto.go
@@ -152,3 +152,41 @@ func NewRoomPriceItemDTO(item RoomPriceItem) RoomPriceItemDTO {
 		Price:    item.Price,
 	}
 }
+
+type RoomsQueryDTO struct {
+	Location     string    `json:"location"`
+	GuestsNumber uint      `json:"guestsNumber"`
+	DateFrom     time.Time `json:"dateFrom"`
+	DateTo       time.Time `json:"dateTo"`
+	PageNumber   uint      `json:"pageNumber"`
+	PageSize     uint      `json:"pageSize"`
+}
+
+type PaginatedResultInfoDTO struct {
+	Page       uint `json:"page"`
+	PageSize   uint `json:"pageSize"`
+	TotalPages uint `json:"totalPages"`
+	TotalHits  uint `json:"totalHits"`
+}
+
+type RoomResultDTO struct {
+	ID          uint     `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Address     string   `json:"address"`
+	Photos      []string `json:"photos" gorm:"type:text;serializer:json"`
+	BasePrice   float32  `json:"basePrice"`
+	TotalPrice  float32  `json:"totalPrice"`
+}
+
+type RoomsResultDTO struct {
+	Hits []RoomResultDTO        `json:"hits"`
+	Info PaginatedResultInfoDTO `json:"info"`
+}
+
+func NewRoomsResultDTO(hits []RoomResultDTO, info PaginatedResultInfoDTO) RoomsResultDTO {
+	return RoomsResultDTO{
+		Hits: hits,
+		Info: info,
+	}
+}

--- a/src/internal/dto.go
+++ b/src/internal/dto.go
@@ -155,11 +155,11 @@ func NewRoomPriceItemDTO(item RoomPriceItem) RoomPriceItemDTO {
 
 type RoomsQueryDTO struct {
 	Location     string    `json:"location"`
-	GuestsNumber uint      `json:"guestsNumber"`
-	DateFrom     time.Time `json:"dateFrom"`
-	DateTo       time.Time `json:"dateTo"`
-	PageNumber   uint      `json:"pageNumber"`
-	PageSize     uint      `json:"pageSize"`
+	GuestsNumber uint      `json:"guestsNumber" binding:"required,min=1"`
+	DateFrom     time.Time `json:"dateFrom" binding:"required"`
+	DateTo       time.Time `json:"dateTo" binding:"required"`
+	PageNumber   uint      `json:"pageNumber" binding:"required,min=1"`
+	PageSize     uint      `json:"pageSize" binding:"required,min=1"`
 }
 
 type PaginatedResultInfoDTO struct {

--- a/src/internal/dto.go
+++ b/src/internal/dto.go
@@ -154,7 +154,7 @@ func NewRoomPriceItemDTO(item RoomPriceItem) RoomPriceItemDTO {
 }
 
 type RoomsQueryDTO struct {
-	Location     string    `json:"location"`
+	Address      string    `json:"address"`
 	GuestsNumber uint      `json:"guestsNumber" binding:"required,min=1"`
 	DateFrom     time.Time `json:"dateFrom" binding:"required"`
 	DateTo       time.Time `json:"dateTo" binding:"required"`
@@ -175,8 +175,22 @@ type RoomResultDTO struct {
 	Description string   `json:"description"`
 	Address     string   `json:"address"`
 	Photos      []string `json:"photos" gorm:"type:text;serializer:json"`
-	BasePrice   float32  `json:"basePrice"`
+	PerGuest    bool     `json:"perGuest"`
+	UnitPrice   float32  `json:"unitPrice"`
 	TotalPrice  float32  `json:"totalPrice"`
+}
+
+func NewRoomResultDTO(room Room, perGuest bool, unitPrice float32, totalPrice float32) RoomResultDTO {
+	return RoomResultDTO{
+		ID:          room.ID,
+		Name:        room.Name,
+		Description: room.Description,
+		Address:     room.Address,
+		Photos:      room.Photos,
+		PerGuest:    perGuest,
+		UnitPrice:   unitPrice,
+		TotalPrice:  totalPrice,
+	}
 }
 
 type RoomsResultDTO struct {

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -18,6 +18,7 @@ func (r *Route) Route(rg *gin.RouterGroup) {
 	rg.POST("/new", r.handler.createRoom)
 	rg.GET("/:id", r.handler.findRoomById)
 	rg.GET("/host/:id", r.handler.findRoomsByHostId)
+	rg.GET("/", r.handler.findAvailableRooms)
 
 	rg.GET("/available/room/:id", r.handler.findCurrentAvailabilityListOfRoom)
 	rg.GET("/available/room/all/:id", r.handler.findAvailabilityListsByRoomId)
@@ -270,4 +271,20 @@ func (h *Handler) updatePriceList(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusCreated, NewRoomPriceListDTO(list))
+}
+
+func (h *Handler) findAvailableRooms(ctx *gin.Context) {
+
+	var dto RoomsQueryDTO
+	if err := ctx.ShouldBindJSON(&dto); err != nil {
+		AbortError(ctx, err)
+	}
+
+	rooms, resultInfo, err := h.service.FindAvailableRooms(dto)
+	if err != nil {
+		AbortError(ctx, err)
+		return
+	}
+
+	ctx.JSON(http.StatusAccepted, NewRoomsResultDTO(rooms, *resultInfo))
 }

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -278,6 +278,7 @@ func (h *Handler) findAvailableRooms(ctx *gin.Context) {
 	var dto RoomsQueryDTO
 	if err := ctx.ShouldBindJSON(&dto); err != nil {
 		AbortError(ctx, err)
+		return
 	}
 
 	rooms, resultInfo, err := h.service.FindAvailableRooms(dto)

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -18,7 +18,7 @@ func (r *Route) Route(rg *gin.RouterGroup) {
 	rg.POST("/new", r.handler.createRoom)
 	rg.GET("/:id", r.handler.findRoomById)
 	rg.GET("/host/:id", r.handler.findRoomsByHostId)
-	rg.GET("/", r.handler.findAvailableRooms)
+	rg.GET("/all", r.handler.findAvailableRooms)
 
 	rg.GET("/available/room/:id", r.handler.findCurrentAvailabilityListOfRoom)
 	rg.GET("/available/room/all/:id", r.handler.findAvailabilityListsByRoomId)

--- a/src/internal/handler.go
+++ b/src/internal/handler.go
@@ -287,5 +287,5 @@ func (h *Handler) findAvailableRooms(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusAccepted, NewRoomsResultDTO(rooms, *resultInfo))
+	ctx.JSON(http.StatusOK, NewRoomsResultDTO(rooms, *resultInfo))
 }

--- a/src/internal/repo.go
+++ b/src/internal/repo.go
@@ -89,17 +89,18 @@ func (r *repository) FindAvailableRooms(location string, guestsNumber uint, date
 		return nil, 0, err
 	}
 
-	find := `SELECT 
-			rooms.id AS ID, 
-			rooms.name AS Name, 
-			rooms.description AS Description, 
-			rooms.address AS Address,  
-			rooms.photos AS Photos, 
-			room_price_lists.base_price AS BasePrice,
+	find := `
+		SELECT 
+			rooms.id, 
+			rooms.name, 
+			rooms.description, 
+			rooms.address,
+			rooms.photos, 
+			room_price_lists.base_price,
 			CASE
 				WHEN per_guest = TRUE THEN temp_table.interval * room_price_lists.base_price * @guestsNumber
 				ELSE temp_table.interval * room_price_lists.base_price
-			END AS TotalPrice
+			END AS total_price
 		FROM temp_table, rooms, room_price_lists
 		WHERE temp_table.room_id = rooms.id and temp_table.available = TRUE 
 			AND rooms.price_list_id = room_price_lists.id

--- a/src/internal/repo.go
+++ b/src/internal/repo.go
@@ -77,7 +77,7 @@ func (r *repository) FindAvailableRooms(location string, guestsNumber uint, date
 		)
 	`
 
-	count := `SELECT COUNT(*) FROM temp_table`
+	count := `SELECT COUNT(*) FROM temp_table WHERE temp_table.available = TRUE`
 	err = r.db.Raw(with+count, map[string]interface{}{
 		"address":      location,
 		"dateFrom":     dateFrom,
@@ -103,7 +103,8 @@ func (r *repository) FindAvailableRooms(location string, guestsNumber uint, date
 			END AS total_price
 		FROM temp_table, rooms, room_price_lists
 		WHERE temp_table.room_id = rooms.id and temp_table.available = TRUE 
-			AND rooms.price_list_id = room_price_lists.id
+			AND rooms.price_list_id 
+			= room_price_lists.id
 		LIMIT @limit OFFSET @offset
 	`
 	offset := int((pageNumber - 1) * pageSize)

--- a/src/internal/repo.go
+++ b/src/internal/repo.go
@@ -53,7 +53,7 @@ func (r *repository) FindByHost(hostId uint) ([]Room, error) {
 
 func (r *repository) FindByFilters(guestsNumber uint, address string) ([]Room, error) {
 	var rooms []Room
-	query := r.db.Where("min_guests < ? and max_guests > ?", guestsNumber, guestsNumber)
+	query := r.db.Where("min_guests <= ? and max_guests >= ?", guestsNumber, guestsNumber)
 
 	if address != "" {
 		query = query.Where("LOWER( ? ) LIKE CONCAT('%' || LOWER(address) || '%')", address)

--- a/src/internal/repo.go
+++ b/src/internal/repo.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"time"
+
 	"gorm.io/gorm"
 )
 
@@ -10,6 +12,7 @@ type Repository interface {
 	Delete(room *Room) error
 	FindById(id uint) (*Room, error)
 	FindByHost(hostId uint) ([]Room, error)
+	FindAvailableRooms(location string, guestsNumber uint, dateFrom time.Time, dateTo time.Time, pageNumber uint, pageSize uint) ([]RoomResultDTO, int64, error)
 }
 
 type repository struct {
@@ -48,4 +51,70 @@ func (r *repository) FindByHost(hostId uint) ([]Room, error) {
 		return nil, err
 	}
 	return rooms, nil
+}
+
+func (r *repository) FindAvailableRooms(location string, guestsNumber uint, dateFrom time.Time, dateTo time.Time, pageNumber uint, pageSize uint) (rooms []RoomResultDTO, totalHits int64, err error) {
+
+	with := `
+		WITH temp_table (room_id, available, interval) AS
+		(
+			SELECT DISTINCT ON
+				(rooms.id) rooms.id,
+				room_availability_items.available,
+				(CAST(@dateTo AS DATE) - CAST(@dateFrom AS DATE)) AS interval
+			FROM rooms
+			INNER JOIN room_availability_list_items 
+				ON rooms.availability_list_id = room_availability_list_items.room_availability_list_id
+			INNER JOIN room_availability_items 
+				ON room_availability_items.id = room_availability_list_items.room_availability_item_id
+			WHERE room_availability_items.date_from <= @dateFrom 
+				AND room_availability_items.date_to >= @dateTo
+				AND min_guests <= @guestsNumber
+				AND max_guests >= @guestsNumber
+				AND (CASE WHEN @address = '' THEN LOWER(address) ELSE LOWER(@address) end) 
+					LIKE CONCAT('%' || LOWER(address) || '%')
+			ORDER BY rooms.id, room_availability_items.date_to - room_availability_items.date_from ASC
+		)
+	`
+
+	count := `SELECT COUNT(*) FROM temp_table`
+	err = r.db.Raw(with+count, map[string]interface{}{
+		"address":      location,
+		"dateFrom":     dateFrom,
+		"dateTo":       dateTo,
+		"guestsNumber": guestsNumber,
+	}).Count(&totalHits).Error
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	find := `SELECT 
+			rooms.id AS ID, 
+			rooms.name AS Name, 
+			rooms.description AS Description, 
+			rooms.address AS Address,  
+			rooms.photos AS Photos, 
+			room_price_lists.base_price AS BasePrice,
+			CASE
+				WHEN per_guest = TRUE THEN temp_table.interval * room_price_lists.base_price * @guestsNumber
+				ELSE temp_table.interval * room_price_lists.base_price
+			END AS TotalPrice
+		FROM temp_table, rooms, room_price_lists
+		WHERE temp_table.room_id = rooms.id and temp_table.available = TRUE 
+			AND rooms.price_list_id = room_price_lists.id
+		LIMIT @limit OFFSET @offset
+	`
+	offset := int((pageNumber - 1) * pageSize)
+	println("offset", offset, "page size", int(pageSize))
+	err = r.db.Raw(with+find, map[string]interface{}{
+		"address":      location,
+		"dateFrom":     dateFrom,
+		"dateTo":       dateTo,
+		"guestsNumber": guestsNumber,
+		"limit":        int(pageSize),
+		"offset":       offset,
+	}).Scan(&rooms).Error
+
+	return rooms, totalHits, nil
 }

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -366,6 +366,7 @@ func (s *service) UpdatePriceList(callerID uint, dto CreateRoomPriceListDTO) (*R
 
 	return &newList, nil
 }
+
 func (s *service) FindAvailableRooms(dto RoomsQueryDTO) ([]RoomResultDTO, *PaginatedResultInfoDTO, error) {
 
 	from := util.ClearYear(dto.DateFrom)

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -368,6 +368,13 @@ func (s *service) UpdatePriceList(callerID uint, dto CreateRoomPriceListDTO) (*R
 }
 func (s *service) FindAvailableRooms(dto RoomsQueryDTO) ([]RoomResultDTO, *PaginatedResultInfoDTO, error) {
 
+	from := util.ClearYear(dto.DateFrom)
+	to := util.ClearYear(dto.DateTo)
+
+	if from.After(to) {
+		return nil, nil, ErrBadRequestCustom(fmt.Sprintf("invalid date range: %v > %v", from, to))
+	}
+
 	rooms, totalHits, err := s.repo.FindAvailableRooms(
 		dto.Location,
 		dto.GuestsNumber,

--- a/src/internal/service.go
+++ b/src/internal/service.go
@@ -5,6 +5,7 @@ import (
 	"bookem-room-service/util"
 	"fmt"
 	"log"
+	"math"
 	"time"
 )
 
@@ -12,6 +13,7 @@ type Service interface {
 	Create(callerID uint, dto CreateRoomDTO) (*Room, error)
 	FindById(id uint) (*Room, error)
 	FindByHost(hostId uint) ([]Room, error)
+	FindAvailableRooms(dto RoomsQueryDTO) ([]RoomResultDTO, *PaginatedResultInfoDTO, error)
 
 	FindAvailabilityListById(id uint) (*RoomAvailabilityList, error)
 	FindAvailabilityListsByRoomId(roomId uint) ([]RoomAvailabilityList, error)
@@ -363,4 +365,30 @@ func (s *service) UpdatePriceList(callerID uint, dto CreateRoomPriceListDTO) (*R
 	}
 
 	return &newList, nil
+}
+func (s *service) FindAvailableRooms(dto RoomsQueryDTO) ([]RoomResultDTO, *PaginatedResultInfoDTO, error) {
+
+	rooms, totalHits, err := s.repo.FindAvailableRooms(
+		dto.Location,
+		dto.GuestsNumber,
+		dto.DateFrom,
+		dto.DateTo,
+		dto.PageNumber,
+		dto.PageSize,
+	)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	totalPages := uint(math.Ceil(float64(totalHits) / float64(dto.PageSize)))
+
+	resultInfo := PaginatedResultInfoDTO{
+		Page:       dto.PageNumber,
+		PageSize:   dto.PageSize,
+		TotalPages: totalPages,
+		TotalHits:  uint(totalHits),
+	}
+
+	return rooms, &resultInfo, nil
 }

--- a/src/test/integration/availability_find_test.go
+++ b/src/test/integration/availability_find_test.go
@@ -1,43 +1,11 @@
-package test
+package integration
 
 import (
-	"bookem-room-service/client/userclient"
-	"bookem-room-service/internal"
-	. "bookem-room-service/test/integration"
-	test "bookem-room-service/test/unit"
-	"bookem-room-service/util"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func createUserAndRoom(username string) (string, *util.Jwt, internal.RoomDTO) {
-	RegisterUser(username, "1234", userclient.Host)
-	jwt := LoginUser2(username, "1234")
-	jwtObj, _ := util.GetJwtFromString(jwt)
-
-	dto := test.DefaultRoomCreateDTO
-	dto.HostID = jwtObj.ID
-	resp, _ := CreateRoom(jwt, dto)
-	room := ResponseToRoom(resp)
-
-	return jwt, jwtObj, room
-}
-
-func createRoomAvailability(jwt string, room internal.RoomDTO) internal.RoomAvailabilityListDTO {
-	dto := internal.CreateRoomAvailabilityListDTO{
-		RoomID: room.ID,
-		Items:  test.DefaultCreateAvailabilityListDTO.Items,
-	}
-
-	resp, err := CreateRoomAvailability(jwt, dto)
-	if err != nil {
-		panic(err)
-	}
-
-	return ResponseToRoomAvailability(resp)
-}
 
 func TestIntegration_FindCurrentAvailabilityListOfRoom_Success(t *testing.T) {
 	username := "host_b_01"
@@ -100,6 +68,7 @@ func TestIntegration_FindAvailabilityListById_Success(t *testing.T) {
 }
 
 func TestIntegration_FindAvailabilityListById_NotFound(t *testing.T) {
+
 	username := "host_b_06"
 	_, _, room := createUserAndRoom(username)
 

--- a/src/test/integration/availability_find_test.go
+++ b/src/test/integration/availability_find_test.go
@@ -68,6 +68,8 @@ func TestIntegration_FindAvailabilityListById_Success(t *testing.T) {
 }
 
 func TestIntegration_FindAvailabilityListById_NotFound(t *testing.T) {
+	cleanup("room")
+	cleanup("user")
 
 	username := "host_b_06"
 	_, _, room := createUserAndRoom(username)

--- a/src/test/integration/availability_find_test.go
+++ b/src/test/integration/availability_find_test.go
@@ -12,14 +12,14 @@ func TestIntegration_FindCurrentAvailabilityListOfRoom_Success(t *testing.T) {
 	jwt, _, room := createUserAndRoom(username)
 
 	// Create 2, so we can check if the second one overrides the first one.
-	createRoomAvailability(jwt, room)
-	availList2 := createRoomAvailability(jwt, room)
+	createRoomAvailabilityList(jwt, room)
+	availList2 := createRoomAvailabilityList(jwt, room)
 
-	resp, err := FindCurrentAvailabilityListOfRoom(room.ID)
+	resp, err := findCurrentAvailabilityListOfRoom(room.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	availListGot := ResponseToRoomAvailability(resp)
+	availListGot := responseToRoomAvailability(resp)
 	require.Equal(t, availList2.ID, availListGot.ID)
 }
 
@@ -27,7 +27,7 @@ func TestIntegration_FindCurrentAvailabilityListOfRoom_NotFound(t *testing.T) {
 	username := "host_b_02"
 	_, _, room := createUserAndRoom(username)
 
-	resp, err := FindCurrentAvailabilityListOfRoom(room.ID)
+	resp, err := findCurrentAvailabilityListOfRoom(room.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
@@ -36,19 +36,19 @@ func TestIntegration_FindAvailabilityListsByRoomId_Success(t *testing.T) {
 	username := "host_b_03"
 	jwt, _, room := createUserAndRoom(username)
 
-	createRoomAvailability(jwt, room)
-	createRoomAvailability(jwt, room)
+	createRoomAvailabilityList(jwt, room)
+	createRoomAvailabilityList(jwt, room)
 
-	resp, err := FindAvailabilityListsByRoomId(room.ID)
+	resp, err := findAvailabilityListsByRoomId(room.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	listsGot := ResponseToRoomAvailabilityLists(resp)
+	listsGot := responseToRoomAvailabilityLists(resp)
 	require.Equal(t, 2, len(listsGot))
 }
 
 func TestIntegration_FindAvailabilityListsByRoomId_NotFound(t *testing.T) {
-	resp, err := FindAvailabilityListsByRoomId(999888777)
+	resp, err := findAvailabilityListsByRoomId(999888777)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
@@ -57,13 +57,13 @@ func TestIntegration_FindAvailabilityListById_Success(t *testing.T) {
 	username := "host_b_05"
 	jwt, _, room := createUserAndRoom(username)
 
-	li := createRoomAvailability(jwt, room)
+	li := createRoomAvailabilityList(jwt, room)
 
-	resp, err := FindAvailabilityListById(li.ID)
+	resp, err := findAvailabilityListById(li.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	listGot := ResponseToRoomAvailability(resp)
+	listGot := responseToRoomAvailability(resp)
 	require.Equal(t, li.ID, listGot.ID)
 }
 
@@ -74,7 +74,7 @@ func TestIntegration_FindAvailabilityListById_NotFound(t *testing.T) {
 	username := "host_b_06"
 	_, _, room := createUserAndRoom(username)
 
-	resp, err := FindAvailabilityListById(room.ID)
+	resp, err := findAvailabilityListById(room.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/src/test/integration/availability_update_test.go
+++ b/src/test/integration/availability_update_test.go
@@ -1,9 +1,8 @@
-package test
+package integration
 
 import (
 	"bookem-room-service/client/userclient"
 	"bookem-room-service/internal"
-	. "bookem-room-service/test/integration"
 	test "bookem-room-service/test/unit"
 	"bookem-room-service/util"
 	"net/http"

--- a/src/test/integration/availability_update_test.go
+++ b/src/test/integration/availability_update_test.go
@@ -14,14 +14,14 @@ import (
 
 func TestIntegration_UpdateAvailability_Success(t *testing.T) {
 	username := "host_a_01"
-	RegisterUser(username, "1234", userclient.Host)
-	jwt := LoginUser2(username, "1234")
+	registerUser(username, "1234", userclient.Host)
+	jwt := loginUser2(username, "1234")
 	jwtObj, _ := util.GetJwtFromString(jwt)
 
 	dto := test.DefaultRoomCreateDTO
 	dto.HostID = jwtObj.ID
-	resp, _ := CreateRoom(jwt, dto)
-	room := ResponseToRoom(resp)
+	resp, _ := createRoom(jwt, dto)
+	room := responseToRoom(resp)
 
 	// This test has two phases:
 	//
@@ -45,14 +45,14 @@ func TestIntegration_UpdateAvailability_Success(t *testing.T) {
 			},
 		}
 
-		resp, err := CreateRoomAvailability(jwt, createRoomDto)
+		resp, err := createRoomAvailability(jwt, createRoomDto)
 		if err != nil {
 			panic(err)
 		}
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-		availList := ResponseToRoomAvailability(resp)
+		availList := responseToRoomAvailability(resp)
 
 		require.Equal(t, 2, len(availList.Items))
 		require.Equal(t, room.ID, availList.RoomID)
@@ -63,8 +63,8 @@ func TestIntegration_UpdateAvailability_Success(t *testing.T) {
 	// is reused in the DB.
 	//
 	{
-		resp, _ := FindCurrentAvailabilityListOfRoom(room.ID)
-		currentAvailabilityList := ResponseToRoomAvailability(resp)
+		resp, _ := findCurrentAvailabilityListOfRoom(room.ID)
+		currentAvailabilityList := responseToRoomAvailability(resp)
 		require.Equal(t, 2, len(currentAvailabilityList.Items))
 
 		// We will remove item [0] and keep item [1].
@@ -95,14 +95,14 @@ func TestIntegration_UpdateAvailability_Success(t *testing.T) {
 			},
 		}
 
-		resp, err := CreateRoomAvailability(jwt, createRoomDto)
+		resp, err := createRoomAvailability(jwt, createRoomDto)
 		if err != nil {
 			panic(err)
 		}
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-		availList := ResponseToRoomAvailability(resp)
+		availList := responseToRoomAvailability(resp)
 
 		require.Equal(t, 2, len(availList.Items))
 		require.Equal(t, room.ID, availList.RoomID)
@@ -110,8 +110,8 @@ func TestIntegration_UpdateAvailability_Success(t *testing.T) {
 		// After it passes, we check if everything is OK
 
 		{
-			resp, _ := FindCurrentAvailabilityListOfRoom(room.ID)
-			newAvailabilityList := ResponseToRoomAvailability(resp)
+			resp, _ := findCurrentAvailabilityListOfRoom(room.ID)
+			newAvailabilityList := responseToRoomAvailability(resp)
 			require.Equal(t, 2, len(currentAvailabilityList.Items))
 
 			foundIDs := []uint{

--- a/src/test/integration/create_integration_test.go
+++ b/src/test/integration/create_integration_test.go
@@ -1,4 +1,4 @@
-package test
+package integration
 
 import (
 	"bookem-room-service/client/userclient"

--- a/src/test/integration/create_integration_test.go
+++ b/src/test/integration/create_integration_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestIntegration_Create_Success(t *testing.T) {
-	RegisterUser("user1", "1234", userclient.Host)
-	jwt := LoginUser2("user1", "1234")
+	registerUser("user1", "1234", userclient.Host)
+	jwt := loginUser2("user1", "1234")
 	jwtObj, err := util.GetJwtFromString(jwt)
 	if err != nil {
 		panic(err)
@@ -20,10 +20,10 @@ func TestIntegration_Create_Success(t *testing.T) {
 
 	dto := test.DefaultRoomCreateDTO
 	dto.HostID = jwtObj.ID
-	resp, err := CreateRoom(jwt, dto)
+	resp, err := createRoom(jwt, dto)
 	require.NoError(t, err)
 
-	result := ResponseToRoom(resp)
+	result := responseToRoom(resp)
 	require.Equal(t, fmt.Sprintf("room-%d-%d.jpg", result.ID, 0), result.Photos[0])
 	require.Equal(t, result.Name, dto.Name)
 	require.Equal(t, result.Address, dto.Address)

--- a/src/test/integration/find_available_rooms_integration_test.go
+++ b/src/test/integration/find_available_rooms_integration_test.go
@@ -19,8 +19,8 @@ func TestIntegration_FindAvailableRooms_Success(t *testing.T) {
 	query.DateFrom = time.Date(2025, 8, 22, 0, 0, 0, 0, time.UTC)
 	query.DateTo = time.Date(2025, 8, 23, 0, 0, 0, 0, time.UTC)
 
-	resp, err := FindAvailableRooms(*query)
-	result := ResponseToFindAvailableRooms(resp)
+	resp, err := findAvailableRooms(*query)
+	result := responseToFindAvailableRooms(resp)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -43,8 +43,8 @@ func TestIntegration_FindAvailableRooms_Pagination_Success(t *testing.T) {
 	query.PageNumber = 3
 	query.PageSize = 2
 
-	resp, err := FindAvailableRooms(*query)
-	result := ResponseToFindAvailableRooms(resp)
+	resp, err := findAvailableRooms(*query)
+	result := responseToFindAvailableRooms(resp)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -57,8 +57,8 @@ func TestIntegration_FindAvailableRooms_Pagination_Success(t *testing.T) {
 	query.PageNumber = 1
 	query.PageSize = 2
 
-	resp, err = FindAvailableRooms(*query)
-	result = ResponseToFindAvailableRooms(resp)
+	resp, err = findAvailableRooms(*query)
+	result = responseToFindAvailableRooms(resp)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -80,8 +80,8 @@ func TestIntegration_FindAvailableRooms_NoHits_Success(t *testing.T) {
 	query.DateFrom = time.Date(2025, 10, 22, 0, 0, 0, 0, time.UTC)
 	query.DateTo = time.Date(2025, 10, 23, 0, 0, 0, 0, time.UTC)
 
-	resp, err := FindAvailableRooms(*query)
-	result := ResponseToFindAvailableRooms(resp)
+	resp, err := findAvailableRooms(*query)
+	result := responseToFindAvailableRooms(resp)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -95,8 +95,8 @@ func TestIntegration_FindAvailableRooms_NoHits_Success(t *testing.T) {
 	query = test.DefaultRoomsQueryDTO
 	query.Location = "unknown address"
 
-	resp, err = FindAvailableRooms(*query)
-	result = ResponseToFindAvailableRooms(resp)
+	resp, err = findAvailableRooms(*query)
+	result = responseToFindAvailableRooms(resp)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -111,8 +111,8 @@ func TestIntegration_FindAvailableRooms_NoHits_Success(t *testing.T) {
 	query.Location = "Room Address"
 	query.GuestsNumber = 9999
 
-	resp, err = FindAvailableRooms(*query)
-	result = ResponseToFindAvailableRooms(resp)
+	resp, err = findAvailableRooms(*query)
+	result = responseToFindAvailableRooms(resp)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -133,7 +133,7 @@ func TestIntegration_FindAvailableRooms_InvalidDate(t *testing.T) {
 	query.DateFrom = time.Date(2025, 10, 23, 0, 0, 0, 0, time.UTC)
 	query.DateTo = time.Date(2025, 10, 22, 0, 0, 0, 0, time.UTC)
 
-	resp, err := FindAvailableRooms(*query)
+	resp, err := findAvailableRooms(*query)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)

--- a/src/test/integration/find_available_rooms_integration_test.go
+++ b/src/test/integration/find_available_rooms_integration_test.go
@@ -1,0 +1,140 @@
+package integration
+
+import (
+	test "bookem-room-service/test/unit"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_FindAvailableRooms_Success(t *testing.T) {
+	cleanup("room")
+	cleanup("user")
+	setupRooms(5)
+
+	query := test.DefaultRoomsQueryDTO
+	query.Location = "Room Address"
+	query.DateFrom = time.Date(2025, 8, 22, 0, 0, 0, 0, time.UTC)
+	query.DateTo = time.Date(2025, 8, 23, 0, 0, 0, 0, time.UTC)
+
+	resp, err := FindAvailableRooms(*query)
+	result := ResponseToFindAvailableRooms(resp)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 5, int(result.Info.TotalHits))
+	require.Equal(t, 5, len(result.Hits))
+	require.Equal(t, query.PageNumber, result.Info.Page)
+	require.Equal(t, query.PageSize, result.Info.PageSize)
+	require.Equal(t, 1, int(result.Info.TotalPages))
+}
+
+func TestIntegration_FindAvailableRooms_Pagination_Success(t *testing.T) {
+	cleanup("room")
+	cleanup("user")
+	setupRooms(5)
+
+	query := test.DefaultRoomsQueryDTO
+	query.Location = "Room Address"
+	query.DateFrom = time.Date(2025, 8, 22, 0, 0, 0, 0, time.UTC)
+	query.DateTo = time.Date(2025, 8, 23, 0, 0, 0, 0, time.UTC)
+	query.PageNumber = 3
+	query.PageSize = 2
+
+	resp, err := FindAvailableRooms(*query)
+	result := ResponseToFindAvailableRooms(resp)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 5, int(result.Info.TotalHits))
+	require.Equal(t, 1, len(result.Hits))
+	require.Equal(t, query.PageNumber, result.Info.Page)
+	require.Equal(t, query.PageSize, result.Info.PageSize)
+	require.Equal(t, 3, int(result.Info.TotalPages))
+
+	query.PageNumber = 1
+	query.PageSize = 2
+
+	resp, err = FindAvailableRooms(*query)
+	result = ResponseToFindAvailableRooms(resp)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 5, int(result.Info.TotalHits))
+	require.Equal(t, 2, len(result.Hits))
+	require.Equal(t, query.PageNumber, result.Info.Page)
+	require.Equal(t, query.PageSize, result.Info.PageSize)
+	require.Equal(t, 3, int(result.Info.TotalPages))
+}
+
+func TestIntegration_FindAvailableRooms_NoHits_Success(t *testing.T) {
+	cleanup("room")
+	cleanup("user")
+	setupRooms(5)
+
+	// [1] No available rooms for a certain date range
+	query := test.DefaultRoomsQueryDTO
+	query.Location = "Room Address"
+	query.DateFrom = time.Date(2025, 10, 22, 0, 0, 0, 0, time.UTC)
+	query.DateTo = time.Date(2025, 10, 23, 0, 0, 0, 0, time.UTC)
+
+	resp, err := FindAvailableRooms(*query)
+	result := ResponseToFindAvailableRooms(resp)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 0, int(result.Info.TotalHits))
+	require.Equal(t, 0, len(result.Hits))
+	require.Equal(t, query.PageNumber, result.Info.Page)
+	require.Equal(t, query.PageSize, result.Info.PageSize)
+	require.Equal(t, 0, int(result.Info.TotalPages))
+
+	// [2] No available rooms for a specific location
+	query = test.DefaultRoomsQueryDTO
+	query.Location = "unknown address"
+
+	resp, err = FindAvailableRooms(*query)
+	result = ResponseToFindAvailableRooms(resp)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 0, int(result.Info.TotalHits))
+	require.Equal(t, 0, len(result.Hits))
+	require.Equal(t, query.PageNumber, result.Info.Page)
+	require.Equal(t, query.PageSize, result.Info.PageSize)
+	require.Equal(t, 0, int(result.Info.TotalPages))
+
+	// [3] No available rooms for the given number of guests
+	query = test.DefaultRoomsQueryDTO
+	query.Location = "Room Address"
+	query.GuestsNumber = 9999
+
+	resp, err = FindAvailableRooms(*query)
+	result = ResponseToFindAvailableRooms(resp)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 0, int(result.Info.TotalHits))
+	require.Equal(t, 0, len(result.Hits))
+	require.Equal(t, query.PageNumber, result.Info.Page)
+	require.Equal(t, query.PageSize, result.Info.PageSize)
+	require.Equal(t, 0, int(result.Info.TotalPages))
+}
+
+func TestIntegration_FindAvailableRooms_InvalidDate(t *testing.T) {
+	cleanup("room")
+	cleanup("user")
+	setupRooms(5)
+
+	query := test.DefaultRoomsQueryDTO
+	query.Location = "Room Address"
+	query.DateFrom = time.Date(2025, 10, 23, 0, 0, 0, 0, time.UTC)
+	query.DateTo = time.Date(2025, 10, 22, 0, 0, 0, 0, time.UTC)
+
+	resp, err := FindAvailableRooms(*query)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/src/test/integration/find_available_rooms_integration_test.go
+++ b/src/test/integration/find_available_rooms_integration_test.go
@@ -15,7 +15,7 @@ func TestIntegration_FindAvailableRooms_Success(t *testing.T) {
 	setupRooms(5)
 
 	query := test.DefaultRoomsQueryDTO
-	query.Location = "Room Address"
+	query.Address = "Room Address"
 	query.DateFrom = time.Date(2025, 8, 22, 0, 0, 0, 0, time.UTC)
 	query.DateTo = time.Date(2025, 8, 23, 0, 0, 0, 0, time.UTC)
 
@@ -37,7 +37,7 @@ func TestIntegration_FindAvailableRooms_Pagination_Success(t *testing.T) {
 	setupRooms(5)
 
 	query := test.DefaultRoomsQueryDTO
-	query.Location = "Room Address"
+	query.Address = "  Room ADDRESS  "
 	query.DateFrom = time.Date(2025, 8, 22, 0, 0, 0, 0, time.UTC)
 	query.DateTo = time.Date(2025, 8, 23, 0, 0, 0, 0, time.UTC)
 	query.PageNumber = 3
@@ -76,7 +76,7 @@ func TestIntegration_FindAvailableRooms_NoHits_Success(t *testing.T) {
 
 	// [1] No available rooms for a certain date range
 	query := test.DefaultRoomsQueryDTO
-	query.Location = "Room Address"
+	query.Address = "Room Address"
 	query.DateFrom = time.Date(2025, 10, 22, 0, 0, 0, 0, time.UTC)
 	query.DateTo = time.Date(2025, 10, 23, 0, 0, 0, 0, time.UTC)
 
@@ -91,9 +91,9 @@ func TestIntegration_FindAvailableRooms_NoHits_Success(t *testing.T) {
 	require.Equal(t, query.PageSize, result.Info.PageSize)
 	require.Equal(t, 0, int(result.Info.TotalPages))
 
-	// [2] No available rooms for a specific location
+	// [2] No available rooms for a specific address
 	query = test.DefaultRoomsQueryDTO
-	query.Location = "unknown address"
+	query.Address = "unknown address"
 
 	resp, err = findAvailableRooms(*query)
 	result = responseToFindAvailableRooms(resp)
@@ -108,7 +108,7 @@ func TestIntegration_FindAvailableRooms_NoHits_Success(t *testing.T) {
 
 	// [3] No available rooms for the given number of guests
 	query = test.DefaultRoomsQueryDTO
-	query.Location = "Room Address"
+	query.Address = "Room Address"
 	query.GuestsNumber = 9999
 
 	resp, err = findAvailableRooms(*query)
@@ -129,7 +129,7 @@ func TestIntegration_FindAvailableRooms_InvalidDate(t *testing.T) {
 	setupRooms(5)
 
 	query := test.DefaultRoomsQueryDTO
-	query.Location = "Room Address"
+	query.Address = "Room Address"
 	query.DateFrom = time.Date(2025, 10, 23, 0, 0, 0, 0, time.UTC)
 	query.DateTo = time.Date(2025, 10, 22, 0, 0, 0, 0, time.UTC)
 

--- a/src/test/integration/find_by_host_integration_test.go
+++ b/src/test/integration/find_by_host_integration_test.go
@@ -1,4 +1,4 @@
-package test
+package integration
 
 import (
 	"bookem-room-service/client/userclient"

--- a/src/test/integration/find_by_host_integration_test.go
+++ b/src/test/integration/find_by_host_integration_test.go
@@ -13,36 +13,36 @@ import (
 )
 
 func TestIntegration_FindByHost_Success(t *testing.T) {
-	RegisterUser("user3", "1234", userclient.Host)
-	jwt := LoginUser2("user3", "1234")
+	registerUser("user3", "1234", userclient.Host)
+	jwt := loginUser2("user3", "1234")
 	jwtObj, _ := util.GetJwtFromString(jwt)
 	hostId := jwtObj.ID
 
 	roomCreateDTO := test.DefaultRoomCreateDTO
 	roomCreateDTO.HostID = hostId
 
-	resp, _ := CreateRoom(jwt, roomCreateDTO)
-	room := ResponseToRoom(resp)
-	resp, _ = CreateRoom(jwt, roomCreateDTO)
-	room2 := ResponseToRoom(resp)
+	resp, _ := createRoom(jwt, roomCreateDTO)
+	room := responseToRoom(resp)
+	resp, _ = createRoom(jwt, roomCreateDTO)
+	room2 := responseToRoom(resp)
 	roomsExpect := []internal.RoomDTO{room, room2}
 
-	resp, err := FindRoomsByHostId(hostId)
+	resp, err := findRoomsByHostId(hostId)
 
 	require.NoError(t, err)
-	roomsGot := ResponseToRooms(resp)
+	roomsGot := responseToRooms(resp)
 	require.Equal(t, roomsExpect, roomsGot)
 }
 
 func TestIntegration_FindByHost_MissingId(t *testing.T) {
-	resp, err := http.Get(fmt.Sprintf("%shost/", URL_room))
+	resp, err := http.Get(fmt.Sprintf("%shost/", url_room))
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestIntegration_FindByHost_HostNotFound(t *testing.T) {
-	resp, err := FindRoomsByHostId(888888)
+	resp, err := findRoomsByHostId(888888)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)

--- a/src/test/integration/find_by_id_integration_test.go
+++ b/src/test/integration/find_by_id_integration_test.go
@@ -1,4 +1,4 @@
-package test
+package integration
 
 import (
 	"bookem-room-service/client/userclient"

--- a/src/test/integration/find_by_id_integration_test.go
+++ b/src/test/integration/find_by_id_integration_test.go
@@ -14,29 +14,29 @@ func TestIntegration_FindById_Success(t *testing.T) {
 	cleanup("room")
 	cleanup("user")
 
-	RegisterUser("user2", "1234", userclient.Host)
-	jwt := LoginUser2("user2", "1234")
+	registerUser("user2", "1234", userclient.Host)
+	jwt := loginUser2("user2", "1234")
 	jwtObj, _ := util.GetJwtFromString(jwt)
 
 	roomCreateDTO := test.DefaultRoomCreateDTO
 	roomCreateDTO.HostID = jwtObj.ID
 
-	resp, _ := CreateRoom(jwt, roomCreateDTO)
-	room := ResponseToRoom(resp)
+	resp, _ := createRoom(jwt, roomCreateDTO)
+	room := responseToRoom(resp)
 
 	roomId := room.ID
 
-	resp, err := FindRoomById(roomId)
+	resp, err := findRoomById(roomId)
 
 	require.NoError(t, err)
-	roomGot := ResponseToRoom(resp)
+	roomGot := responseToRoom(resp)
 
 	require.Equal(t, roomId, roomGot.ID)
 	require.Equal(t, room, roomGot)
 }
 
 func TestIntegration_FindById_MissingId(t *testing.T) {
-	resp, err := http.Get(URL_room)
+	resp, err := http.Get(url_room)
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)

--- a/src/test/integration/find_by_id_integration_test.go
+++ b/src/test/integration/find_by_id_integration_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestIntegration_FindById_Success(t *testing.T) {
+	cleanup("room")
+	cleanup("user")
+
 	RegisterUser("user2", "1234", userclient.Host)
 	jwt := LoginUser2("user2", "1234")
 	jwtObj, _ := util.GetJwtFromString(jwt)

--- a/src/test/integration/main_test.go
+++ b/src/test/integration/main_test.go
@@ -1,0 +1,121 @@
+package integration
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+type dbItem struct {
+	Service    string
+	Connection *gorm.DB
+}
+
+var dBs []dbItem
+var services = []string{"room", "user"}
+
+func getConnection(service string) *gorm.DB {
+
+	var connection *gorm.DB
+
+	for _, dbItem := range dBs {
+		if service == dbItem.Service {
+			connection = dbItem.Connection
+			break
+		}
+	}
+
+	if connection == nil {
+		panic(fmt.Sprintf("no %v-database connection found", service))
+	}
+
+	return connection
+}
+
+func cleanup(service string) {
+
+	var db *gorm.DB = getConnection(service)
+
+	var tables []string
+	err := db.Raw("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'").Scan(&tables).Error
+	if err != nil {
+		log.Fatalf("error fetching table names: %v", err)
+	}
+
+	for _, table := range tables {
+		query := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", table)
+		err = db.Exec(query).Error
+		if err != nil {
+			log.Fatalf("error truncating table %s: %v", table, err)
+		}
+	}
+
+	log.Printf("%v-database cleaned up successfully", service)
+}
+
+func connectToDBs() {
+
+	for _, service := range services {
+
+		s := strings.ToUpper(service)
+		host := os.Getenv(fmt.Sprintf("%s_DB_HOST", s))
+		port := os.Getenv(fmt.Sprintf("%s_DB_PORT", s))
+		user := os.Getenv(fmt.Sprintf("%s_DB_USER", s))
+		password := os.Getenv(fmt.Sprintf("%s_DB_PASSWORD", s))
+		dbname := os.Getenv(fmt.Sprintf("%s_DB_NAME", s))
+
+		dbURL := fmt.Sprintf(
+			"host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+			host, port, user, password, dbname,
+		)
+
+		db, err := gorm.Open(postgres.Open(dbURL), &gorm.Config{})
+		if err != nil {
+			log.Fatalf("failed to open %v-database", err)
+		}
+
+		dbItem := dbItem{
+			Service:    service,
+			Connection: db,
+		}
+
+		dBs = append(dBs, dbItem)
+
+		log.Printf("connected to %v-database", service)
+	}
+
+}
+
+func closeDBConnections() {
+	for _, dbItem := range dBs {
+		db, err := dbItem.Connection.DB()
+
+		if err != nil {
+			log.Printf("error getting %v-database instance: %v", dbItem.Service, err)
+			continue
+		}
+
+		err = db.Close()
+		if err != nil {
+			log.Printf("error closing %v-database connection: %v", dbItem.Service, err)
+		} else {
+			log.Printf("closed connection to %v-database", dbItem.Service)
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+
+	connectToDBs()
+
+	code := m.Run()
+
+	closeDBConnections()
+
+	os.Exit(code)
+}

--- a/src/test/integration/price_find_test.go
+++ b/src/test/integration/price_find_test.go
@@ -12,14 +12,14 @@ func TestIntegration_FindCurrentPriceListOfRoom_Success(t *testing.T) {
 	jwt, _, room := createUserAndRoomForPrice(username)
 
 	// Create 2, so we can check if the second one overrides the first one.
-	createRoomPrice(jwt, room)
-	priceList2 := createRoomPrice(jwt, room)
+	createRoomPriceList(jwt, room)
+	priceList2 := createRoomPriceList(jwt, room)
 
-	resp, err := FindCurrentPriceListOfRoom(room.ID)
+	resp, err := findCurrentPriceListOfRoom(room.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	priceListGot := ResponseToRoomPrice(resp)
+	priceListGot := responseToRoomPrice(resp)
 	require.Equal(t, priceList2.ID, priceListGot.ID)
 }
 
@@ -27,7 +27,7 @@ func TestIntegration_FindCurrentPriceListOfRoom_NotFound(t *testing.T) {
 	username := "host_p_02"
 	_, _, room := createUserAndRoomForPrice(username)
 
-	resp, err := FindCurrentPriceListOfRoom(room.ID)
+	resp, err := findCurrentPriceListOfRoom(room.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
@@ -36,19 +36,19 @@ func TestIntegration_FindPriceListsByRoomId_Success(t *testing.T) {
 	username := "host_p_03"
 	jwt, _, room := createUserAndRoomForPrice(username)
 
-	createRoomPrice(jwt, room)
-	createRoomPrice(jwt, room)
+	createRoomPriceList(jwt, room)
+	createRoomPriceList(jwt, room)
 
-	resp, err := FindPriceListsByRoomId(room.ID)
+	resp, err := findPriceListsByRoomId(room.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	listsGot := ResponseToRoomPriceLists(resp)
+	listsGot := responseToRoomPriceLists(resp)
 	require.Equal(t, 2, len(listsGot))
 }
 
 func TestIntegration_FindPriceListsByRoomId_NotFound(t *testing.T) {
-	resp, err := FindPriceListsByRoomId(999888777)
+	resp, err := findPriceListsByRoomId(999888777)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
@@ -57,13 +57,13 @@ func TestIntegration_FindPriceListById_Success(t *testing.T) {
 	username := "host_p_05"
 	jwt, _, room := createUserAndRoomForPrice(username)
 
-	li := createRoomPrice(jwt, room)
+	li := createRoomPriceList(jwt, room)
 
-	resp, err := FindPriceListById(li.ID)
+	resp, err := findPriceListById(li.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	listGot := ResponseToRoomPrice(resp)
+	listGot := responseToRoomPrice(resp)
 	require.Equal(t, li.ID, listGot.ID)
 }
 
@@ -71,7 +71,7 @@ func TestIntegration_FindPriceListById_NotFound(t *testing.T) {
 	username := "host_p_06"
 	_, _, room := createUserAndRoomForPrice(username)
 
-	resp, err := FindPriceListById(room.ID)
+	resp, err := findPriceListById(room.ID)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/src/test/integration/price_find_test.go
+++ b/src/test/integration/price_find_test.go
@@ -1,43 +1,11 @@
-package test
+package integration
 
 import (
-	"bookem-room-service/client/userclient"
-	"bookem-room-service/internal"
-	. "bookem-room-service/test/integration"
-	test "bookem-room-service/test/unit"
-	"bookem-room-service/util"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func createUserAndRoomForPrice(username string) (string, *util.Jwt, internal.RoomDTO) {
-	RegisterUser(username, "1234", userclient.Host)
-	jwt := LoginUser2(username, "1234")
-	jwtObj, _ := util.GetJwtFromString(jwt)
-
-	dto := test.DefaultRoomCreateDTO
-	dto.HostID = jwtObj.ID
-	resp, _ := CreateRoom(jwt, dto)
-	room := ResponseToRoom(resp)
-
-	return jwt, jwtObj, room
-}
-
-func createRoomPrice(jwt string, room internal.RoomDTO) internal.RoomPriceListDTO {
-	dto := internal.CreateRoomPriceListDTO{
-		RoomID: room.ID,
-		Items:  test.DefaultCreatePriceListDTO.Items,
-	}
-
-	resp, err := CreateRoomPrice(jwt, dto)
-	if err != nil {
-		panic(err)
-	}
-
-	return ResponseToRoomPrice(resp)
-}
 
 func TestIntegration_FindCurrentPriceListOfRoom_Success(t *testing.T) {
 	username := "host_p_01"

--- a/src/test/integration/price_update_test.go
+++ b/src/test/integration/price_update_test.go
@@ -1,9 +1,8 @@
-package test
+package integration
 
 import (
 	"bookem-room-service/client/userclient"
 	"bookem-room-service/internal"
-	. "bookem-room-service/test/integration"
 	test "bookem-room-service/test/unit"
 	"bookem-room-service/util"
 	"net/http"

--- a/src/test/integration/price_update_test.go
+++ b/src/test/integration/price_update_test.go
@@ -14,14 +14,14 @@ import (
 
 func TestIntegration_UpdatePriceList_Success(t *testing.T) {
 	username := "host_pu_01"
-	RegisterUser(username, "1234", userclient.Host)
-	jwt := LoginUser2(username, "1234")
+	registerUser(username, "1234", userclient.Host)
+	jwt := loginUser2(username, "1234")
 	jwtObj, _ := util.GetJwtFromString(jwt)
 
 	dto := test.DefaultRoomCreateDTO
 	dto.HostID = jwtObj.ID
-	resp, _ := CreateRoom(jwt, dto)
-	room := ResponseToRoom(resp)
+	resp, _ := createRoom(jwt, dto)
+	room := responseToRoom(resp)
 
 	// [Phase 1] Create initial price list
 	{
@@ -43,19 +43,19 @@ func TestIntegration_UpdatePriceList_Success(t *testing.T) {
 			},
 		}
 
-		resp, err := CreateRoomPrice(jwt, createPriceDto)
+		resp, err := createRoomPrice(jwt, createPriceDto)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-		priceList := ResponseToRoomPrice(resp)
+		priceList := responseToRoomPrice(resp)
 		require.Equal(t, 2, len(priceList.Items))
 		require.Equal(t, room.ID, priceList.RoomID)
 	}
 
 	// [Phase 2] Update price list: reuse one item, add a new one
 	{
-		resp, _ := FindCurrentPriceListOfRoom(room.ID)
-		currentPriceList := ResponseToRoomPrice(resp)
+		resp, _ := findCurrentPriceListOfRoom(room.ID)
+		currentPriceList := responseToRoomPrice(resp)
 		require.Equal(t, 2, len(currentPriceList.Items))
 
 		// Remove item [0], keep item [1], add new item
@@ -77,18 +77,18 @@ func TestIntegration_UpdatePriceList_Success(t *testing.T) {
 			Items:  []internal.CreateRoomPriceItemDTO{itemToAdd, itemToKeep},
 		}
 
-		resp, err := CreateRoomPrice(jwt, updatePriceDto)
+		resp, err := createRoomPrice(jwt, updatePriceDto)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-		priceList := ResponseToRoomPrice(resp)
+		priceList := responseToRoomPrice(resp)
 		require.Equal(t, 2, len(priceList.Items))
 		require.Equal(t, room.ID, priceList.RoomID)
 
 		// Final check: confirm reuse and replacement
 		{
-			resp, _ := FindCurrentPriceListOfRoom(room.ID)
-			newPriceList := ResponseToRoomPrice(resp)
+			resp, _ := findCurrentPriceListOfRoom(room.ID)
+			newPriceList := responseToRoomPrice(resp)
 			require.Equal(t, 2, len(newPriceList.Items))
 
 			foundIDs := []uint{

--- a/src/test/integration/util.go
+++ b/src/test/integration/util.go
@@ -1,4 +1,4 @@
-package test
+package integration
 
 import (
 	"bookem-room-service/client/userclient"
@@ -248,3 +248,58 @@ func FindPriceListById(id uint) (*http.Response, error) {
 	resp, err := http.Get(fmt.Sprintf("%sprice/%d", URL_room, id))
 	return resp, err
 }
+
+func createUserAndRoom(username string) (string, *util.Jwt, internal.RoomDTO) {
+	RegisterUser(username, "1234", userclient.Host)
+	jwt := LoginUser2(username, "1234")
+	jwtObj, _ := util.GetJwtFromString(jwt)
+
+	dto := test.DefaultRoomCreateDTO
+	dto.HostID = jwtObj.ID
+	resp, _ := CreateRoom(jwt, dto)
+	room := ResponseToRoom(resp)
+
+	return jwt, jwtObj, room
+}
+
+func createRoomAvailability(jwt string, room internal.RoomDTO) internal.RoomAvailabilityListDTO {
+	dto := internal.CreateRoomAvailabilityListDTO{
+		RoomID: room.ID,
+		Items:  test.DefaultCreateAvailabilityListDTO.Items,
+	}
+
+	resp, err := CreateRoomAvailability(jwt, dto)
+	if err != nil {
+		panic(err)
+	}
+
+	return ResponseToRoomAvailability(resp)
+}
+
+func createUserAndRoomForPrice(username string) (string, *util.Jwt, internal.RoomDTO) {
+	RegisterUser(username, "1234", userclient.Host)
+	jwt := LoginUser2(username, "1234")
+	jwtObj, _ := util.GetJwtFromString(jwt)
+
+	dto := test.DefaultRoomCreateDTO
+	dto.HostID = jwtObj.ID
+	resp, _ := CreateRoom(jwt, dto)
+	room := ResponseToRoom(resp)
+
+	return jwt, jwtObj, room
+}
+
+func createRoomPrice(jwt string, room internal.RoomDTO) internal.RoomPriceListDTO {
+	dto := internal.CreateRoomPriceListDTO{
+		RoomID: room.ID,
+		Items:  test.DefaultCreatePriceListDTO.Items,
+	}
+
+	resp, err := CreateRoomPrice(jwt, dto)
+	if err != nil {
+		panic(err)
+	}
+
+	return ResponseToRoomPrice(resp)
+}
+

--- a/src/test/integration/util.go
+++ b/src/test/integration/util.go
@@ -14,12 +14,12 @@ import (
 	"strings"
 )
 
-const URL_user = "http://user-service:8080/api/"
-const URL_room = "http://room-service:8080/api/"
+const url_user = "http://user-service:8080/api/"
+const url_room = "http://room-service:8080/api/"
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
-func GenName(length int) string {
+func genName(length int) string {
 	b := make([]rune, length)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
@@ -27,7 +27,7 @@ func GenName(length int) string {
 	return string(b)
 }
 
-func RegisterUser(username_or_email string, password string, role userclient.UserRole) (*http.Response, error) {
+func registerUser(username_or_email string, password string, role userclient.UserRole) (*http.Response, error) {
 	username := username_or_email
 	email := username + "@gmail.com"
 
@@ -41,9 +41,9 @@ func RegisterUser(username_or_email string, password string, role userclient.Use
 		Password: password,
 		Email:    email,
 		Role:     string(role),
-		Name:     GenName(6),
-		Surname:  GenName(6),
-		Address:  GenName(10),
+		Name:     genName(6),
+		Surname:  genName(6),
+		Address:  genName(10),
 	}
 
 	jsonBytes, err := json.Marshal(dto)
@@ -51,11 +51,11 @@ func RegisterUser(username_or_email string, password string, role userclient.Use
 		return nil, err
 	}
 
-	resp, err := http.Post(URL_user+"register", "application/json", bytes.NewBuffer(jsonBytes))
+	resp, err := http.Post(url_user+"register", "application/json", bytes.NewBuffer(jsonBytes))
 	return resp, err
 }
 
-func LoginUser(username_or_email string, password string) (*http.Response, error) {
+func loginUser(username_or_email string, password string) (*http.Response, error) {
 	dto := userclient.LoginDTO{
 		UsernameOrEmail: username_or_email,
 		Password:        password,
@@ -66,12 +66,12 @@ func LoginUser(username_or_email string, password string) (*http.Response, error
 		return nil, err
 	}
 
-	resp, err := http.Post(URL_user+"login", "application/json", bytes.NewBuffer(jsonBytes))
+	resp, err := http.Post(url_user+"login", "application/json", bytes.NewBuffer(jsonBytes))
 	return resp, err
 }
 
-func LoginUser2(username_or_email string, password string) string {
-	resp, _ := LoginUser(username_or_email, password)
+func loginUser2(username_or_email string, password string) string {
+	resp, _ := loginUser(username_or_email, password)
 
 	defer resp.Body.Close()
 
@@ -88,13 +88,13 @@ func LoginUser2(username_or_email string, password string) string {
 	return token.Jwt
 }
 
-func CreateRoom(jwt string, dto internal.CreateRoomDTO) (*http.Response, error) {
+func createRoom(jwt string, dto internal.CreateRoomDTO) (*http.Response, error) {
 	jsonBytes, err := json.Marshal(dto)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, URL_room+"new", bytes.NewBuffer(jsonBytes))
+	req, err := http.NewRequest(http.MethodPost, url_room+"new", bytes.NewBuffer(jsonBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -102,30 +102,30 @@ func CreateRoom(jwt string, dto internal.CreateRoomDTO) (*http.Response, error) 
 	return http.DefaultClient.Do(req)
 }
 
-func FindRoomById(id uint) (*http.Response, error) {
-	resp, err := http.Get(fmt.Sprintf("%s%d", URL_room, id)) // No forward slash between them, it's in `URL`
+func findRoomById(id uint) (*http.Response, error) {
+	resp, err := http.Get(fmt.Sprintf("%s%d", url_room, id)) // No forward slash between them, it's in `URL`
 	return resp, err
 }
 
-func FindAvailableRooms(dto internal.RoomsQueryDTO) (*http.Response, error) {
+func findAvailableRooms(dto internal.RoomsQueryDTO) (*http.Response, error) {
 	jsonBytes, err := json.Marshal(dto)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodGet, URL_room+"all", bytes.NewBuffer(jsonBytes))
+	req, err := http.NewRequest(http.MethodGet, url_room+"all", bytes.NewBuffer(jsonBytes))
 	if err != nil {
 		return nil, err
 	}
 	return http.DefaultClient.Do(req)
 }
 
-func FindRoomsByHostId(hostId uint) (*http.Response, error) {
-	resp, err := http.Get(fmt.Sprintf("%shost/%d", URL_room, hostId)) // No forward slash between them, it's in `URL`
+func findRoomsByHostId(hostId uint) (*http.Response, error) {
+	resp, err := http.Get(fmt.Sprintf("%shost/%d", url_room, hostId)) // No forward slash between them, it's in `URL`
 	return resp, err
 }
 
-func ResponseToRoom(resp *http.Response) internal.RoomDTO {
+func responseToRoom(resp *http.Response) internal.RoomDTO {
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(fmt.Sprintf("failed to read response body: %v", err))
@@ -140,7 +140,7 @@ func ResponseToRoom(resp *http.Response) internal.RoomDTO {
 	return obj
 }
 
-func ResponseToRooms(resp *http.Response) []internal.RoomDTO {
+func responseToRooms(resp *http.Response) []internal.RoomDTO {
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(fmt.Sprintf("failed to read response body: %v", err))
@@ -154,13 +154,13 @@ func ResponseToRooms(resp *http.Response) []internal.RoomDTO {
 	return obj
 }
 
-func CreateRoomAvailability(jwt string, dto internal.CreateRoomAvailabilityListDTO) (*http.Response, error) {
+func createRoomAvailability(jwt string, dto internal.CreateRoomAvailabilityListDTO) (*http.Response, error) {
 	jsonBytes, err := json.Marshal(dto)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, URL_room+"available", bytes.NewBuffer(jsonBytes))
+	req, err := http.NewRequest(http.MethodPost, url_room+"available", bytes.NewBuffer(jsonBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func CreateRoomAvailability(jwt string, dto internal.CreateRoomAvailabilityListD
 	return http.DefaultClient.Do(req)
 }
 
-func ResponseToRoomAvailability(resp *http.Response) internal.RoomAvailabilityListDTO {
+func responseToRoomAvailability(resp *http.Response) internal.RoomAvailabilityListDTO {
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(fmt.Sprintf("failed to read response body: %v", err))
@@ -182,7 +182,7 @@ func ResponseToRoomAvailability(resp *http.Response) internal.RoomAvailabilityLi
 	return obj
 }
 
-func ResponseToFindAvailableRooms(resp *http.Response) internal.RoomsResultDTO {
+func responseToFindAvailableRooms(resp *http.Response) internal.RoomsResultDTO {
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(fmt.Sprintf("failed to read response body: %v", err))
@@ -197,22 +197,22 @@ func ResponseToFindAvailableRooms(resp *http.Response) internal.RoomsResultDTO {
 	return obj
 }
 
-func FindCurrentAvailabilityListOfRoom(roomId uint) (*http.Response, error) {
-	resp, err := http.Get(fmt.Sprintf("%savailable/room/%d", URL_room, roomId))
+func findCurrentAvailabilityListOfRoom(roomId uint) (*http.Response, error) {
+	resp, err := http.Get(fmt.Sprintf("%savailable/room/%d", url_room, roomId))
 	return resp, err
 }
 
-func FindAvailabilityListsByRoomId(roomId uint) (*http.Response, error) {
-	resp, err := http.Get(fmt.Sprintf("%savailable/room/all/%d", URL_room, roomId))
+func findAvailabilityListsByRoomId(roomId uint) (*http.Response, error) {
+	resp, err := http.Get(fmt.Sprintf("%savailable/room/all/%d", url_room, roomId))
 	return resp, err
 }
 
-func FindAvailabilityListById(id uint) (*http.Response, error) {
-	resp, err := http.Get(fmt.Sprintf("%savailable/%d", URL_room, id))
+func findAvailabilityListById(id uint) (*http.Response, error) {
+	resp, err := http.Get(fmt.Sprintf("%savailable/%d", url_room, id))
 	return resp, err
 }
 
-func ResponseToRoomAvailabilityLists(resp *http.Response) []internal.RoomAvailabilityListDTO {
+func responseToRoomAvailabilityLists(resp *http.Response) []internal.RoomAvailabilityListDTO {
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(fmt.Sprintf("failed to read response body: %v", err))
@@ -226,13 +226,13 @@ func ResponseToRoomAvailabilityLists(resp *http.Response) []internal.RoomAvailab
 	return obj
 }
 
-func CreateRoomPrice(jwt string, dto internal.CreateRoomPriceListDTO) (*http.Response, error) {
+func createRoomPrice(jwt string, dto internal.CreateRoomPriceListDTO) (*http.Response, error) {
 	jsonBytes, err := json.Marshal(dto)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, URL_room+"price", bytes.NewBuffer(jsonBytes))
+	req, err := http.NewRequest(http.MethodPost, url_room+"price", bytes.NewBuffer(jsonBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func CreateRoomPrice(jwt string, dto internal.CreateRoomPriceListDTO) (*http.Res
 	return http.DefaultClient.Do(req)
 }
 
-func ResponseToRoomPrice(resp *http.Response) internal.RoomPriceListDTO {
+func responseToRoomPrice(resp *http.Response) internal.RoomPriceListDTO {
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(fmt.Sprintf("failed to read response body: %v", err))
@@ -253,7 +253,7 @@ func ResponseToRoomPrice(resp *http.Response) internal.RoomPriceListDTO {
 
 	return obj
 }
-func ResponseToRoomPriceLists(resp *http.Response) []internal.RoomPriceListDTO {
+func responseToRoomPriceLists(resp *http.Response) []internal.RoomPriceListDTO {
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		panic(fmt.Sprintf("failed to read response body: %v", err))
@@ -266,78 +266,78 @@ func ResponseToRoomPriceLists(resp *http.Response) []internal.RoomPriceListDTO {
 
 	return obj
 }
-func FindCurrentPriceListOfRoom(roomId uint) (*http.Response, error) {
-	resp, err := http.Get(fmt.Sprintf("%sprice/room/%d", URL_room, roomId))
+func findCurrentPriceListOfRoom(roomId uint) (*http.Response, error) {
+	resp, err := http.Get(fmt.Sprintf("%sprice/room/%d", url_room, roomId))
 	return resp, err
 }
-func FindPriceListsByRoomId(roomId uint) (*http.Response, error) {
-	resp, err := http.Get(fmt.Sprintf("%sprice/room/all/%d", URL_room, roomId))
+func findPriceListsByRoomId(roomId uint) (*http.Response, error) {
+	resp, err := http.Get(fmt.Sprintf("%sprice/room/all/%d", url_room, roomId))
 	return resp, err
 }
-func FindPriceListById(id uint) (*http.Response, error) {
-	resp, err := http.Get(fmt.Sprintf("%sprice/%d", URL_room, id))
+func findPriceListById(id uint) (*http.Response, error) {
+	resp, err := http.Get(fmt.Sprintf("%sprice/%d", url_room, id))
 	return resp, err
 }
 
 func createUserAndRoom(username string) (string, *util.Jwt, internal.RoomDTO) {
-	RegisterUser(username, "1234", userclient.Host)
-	jwt := LoginUser2(username, "1234")
+	registerUser(username, "1234", userclient.Host)
+	jwt := loginUser2(username, "1234")
 	jwtObj, _ := util.GetJwtFromString(jwt)
 
 	dto := test.DefaultRoomCreateDTO
 	dto.HostID = jwtObj.ID
-	resp, _ := CreateRoom(jwt, dto)
-	room := ResponseToRoom(resp)
+	resp, _ := createRoom(jwt, dto)
+	room := responseToRoom(resp)
 
 	return jwt, jwtObj, room
 }
 
-func createRoomAvailability(jwt string, room internal.RoomDTO) internal.RoomAvailabilityListDTO {
+func createRoomAvailabilityList(jwt string, room internal.RoomDTO) internal.RoomAvailabilityListDTO {
 	dto := internal.CreateRoomAvailabilityListDTO{
 		RoomID: room.ID,
 		Items:  test.DefaultCreateAvailabilityListDTO.Items,
 	}
 
-	resp, err := CreateRoomAvailability(jwt, dto)
+	resp, err := createRoomAvailability(jwt, dto)
 	if err != nil {
 		panic(err)
 	}
 
-	return ResponseToRoomAvailability(resp)
+	return responseToRoomAvailability(resp)
 }
 
 func createUserAndRoomForPrice(username string) (string, *util.Jwt, internal.RoomDTO) {
-	RegisterUser(username, "1234", userclient.Host)
-	jwt := LoginUser2(username, "1234")
+	registerUser(username, "1234", userclient.Host)
+	jwt := loginUser2(username, "1234")
 	jwtObj, _ := util.GetJwtFromString(jwt)
 
 	dto := test.DefaultRoomCreateDTO
 	dto.HostID = jwtObj.ID
-	resp, _ := CreateRoom(jwt, dto)
-	room := ResponseToRoom(resp)
+	resp, _ := createRoom(jwt, dto)
+	room := responseToRoom(resp)
 
 	return jwt, jwtObj, room
 }
 
-func createRoomPrice(jwt string, room internal.RoomDTO) internal.RoomPriceListDTO {
+func createRoomPriceList(jwt string, room internal.RoomDTO) internal.RoomPriceListDTO {
 	dto := internal.CreateRoomPriceListDTO{
 		RoomID: room.ID,
 		Items:  test.DefaultCreatePriceListDTO.Items,
 	}
 
-	resp, err := CreateRoomPrice(jwt, dto)
+	resp, err := createRoomPrice(jwt, dto)
 	if err != nil {
 		panic(err)
 	}
 
-	return ResponseToRoomPrice(resp)
+	return responseToRoomPrice(resp)
 }
 
 func setupRooms(quantity int) {
 	for i := range quantity {
 		username := fmt.Sprintf("host%d", i)
 		jwt, _, room := createUserAndRoom(username)
-		createRoomAvailability(jwt, room)
-		createRoomPrice(jwt, room)
+		createRoomAvailabilityList(jwt, room)
+		createRoomPriceList(jwt, room)
 	}
 }

--- a/src/test/unit/find_available_rooms_test.go
+++ b/src/test/unit/find_available_rooms_test.go
@@ -1,0 +1,68 @@
+package test
+
+import (
+	"bookem-room-service/internal"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FindAvailableRooms_Success(t *testing.T) {
+	svc, mockRepo, _, _, _ := CreateTestRoomService()
+
+	room1 := DefaultRoomResult
+	room2 := DefaultRoomResult
+	room3 := DefaultRoomResult
+	info := DefaulPaginatedResultInfoDTO
+	d := *DefaultRoomsQueryDTO
+
+	rooms := []internal.RoomResultDTO{*room1, *room2, *room3}
+	var totalHits int64 = 3
+
+	mockRepo.
+		On("FindAvailableRooms", d.Location, d.GuestsNumber, d.DateFrom, d.DateTo, d.PageNumber, d.PageSize).
+		Return(rooms, totalHits, nil)
+
+	roomsGot, infoGot, err := svc.FindAvailableRooms(d)
+
+	assert.NoError(t, err)
+	assert.Equal(t, rooms, roomsGot)
+	assert.Equal(t, info, infoGot)
+	mockRepo.AssertNumberOfCalls(t, "FindAvailableRooms", 1)
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_FindAvailableRooms_InvalidDate(t *testing.T) {
+	svc, mockRepo, _, _, _ := CreateTestRoomService()
+
+	d := *DefaultRoomsQueryDTO
+	d.DateFrom = d.DateTo.Add(24 * time.Hour)
+
+	roomsGot, infoGot, err := svc.FindAvailableRooms(d)
+
+	assert.Nil(t, roomsGot)
+	assert.Nil(t, infoGot)
+	assert.Error(t, err)
+	mockRepo.AssertNumberOfCalls(t, "FindAvailableRooms", 0)
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_FindAvailableRooms_DbError(t *testing.T) {
+	svc, mockRepo, _, _, _ := CreateTestRoomService()
+
+	d := *DefaultRoomsQueryDTO
+
+	mockRepo.
+		On("FindAvailableRooms", d.Location, d.GuestsNumber, d.DateFrom, d.DateTo, d.PageNumber, d.PageSize).
+		Return(nil, nil, fmt.Errorf("db error"))
+
+	roomsGot, infoGot, err := svc.FindAvailableRooms(d)
+
+	assert.Nil(t, roomsGot)
+	assert.Nil(t, infoGot)
+	assert.Error(t, err)
+	mockRepo.AssertNumberOfCalls(t, "FindAvailableRooms", 1)
+	mockRepo.AssertExpectations(t)
+}

--- a/src/test/unit/find_available_rooms_test.go
+++ b/src/test/unit/find_available_rooms_test.go
@@ -26,44 +26,61 @@ func Test_ClearYear_Success(t *testing.T) {
 	assert.NotEqual(t, date2Res.Year(), date2.Year())
 }
 
-func Test_CheckPrice_BasePrice_Success(t *testing.T) {
+func Test_CalculatePriceForOneDay_BasePrice_Success(t *testing.T) {
 	svc, _, _, _, _ := CreateTestRoomService()
 	day := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	day = util.ClearYear(day)
 	basePrice := uint(1000)
 	rulePrice := uint(100)
+	guests := uint(4)
 
+	var rules internal.RoomPriceList = internal.RoomPriceList{
+		ID:            1,
+		RoomID:        1,
+		EffectiveFrom: time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		BasePrice:     basePrice,
+		PerGuest:      true,
+		Items:         []internal.RoomPriceItem{},
+	}
 	rule := internal.RoomPriceItem{
 		ID:       1,
 		DateFrom: time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
 		DateTo:   time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
 		Price:    rulePrice,
 	}
-	rules := []internal.RoomPriceItem{rule}
+	rules.Items = append(rules.Items, rule)
 
-	priceRes := svc.CheckPrice(day, uint(basePrice), rules)
+	priceRes := svc.CalculatePriceForOneDay(day, guests, rules)
 
-	assert.Equal(t, basePrice, priceRes)
+	assert.Equal(t, float32(guests*basePrice), priceRes)
 }
 
-func Test_CheckPrice_DefinedPriceByRule_Success(t *testing.T) {
+func Test_CalculatePriceForOneDay_DefinedPriceByRule_Success(t *testing.T) {
 	svc, _, _, _, _ := CreateTestRoomService()
 	day := time.Date(2025, 8, 13, 0, 0, 0, 0, time.UTC)
 	day = util.ClearYear(day)
 	basePrice := uint(1000)
 	rulePrice := uint(100)
 
+	var rules internal.RoomPriceList = internal.RoomPriceList{
+		ID:            1,
+		RoomID:        1,
+		EffectiveFrom: time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		BasePrice:     basePrice,
+		PerGuest:      false,
+		Items:         []internal.RoomPriceItem{},
+	}
 	rule := internal.RoomPriceItem{
 		ID:       1,
 		DateFrom: time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
 		DateTo:   time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
 		Price:    rulePrice,
 	}
-	rules := []internal.RoomPriceItem{rule}
+	rules.Items = append(rules.Items, rule)
 
-	priceRes := svc.CheckPrice(day, uint(basePrice), rules)
+	priceRes := svc.CalculatePriceForOneDay(day, uint(4), rules)
 
-	assert.Equal(t, rulePrice, priceRes)
+	assert.Equal(t, float32(rulePrice), priceRes)
 }
 
 func Test_CalculatePrice_UndefinedRules_Fail(t *testing.T) {

--- a/src/test/unit/find_available_rooms_test.go
+++ b/src/test/unit/find_available_rooms_test.go
@@ -180,7 +180,7 @@ func Test_CalculatePrice_FlatPrice_Success(t *testing.T) {
 	mockPriceRepo.AssertExpectations(t)
 }
 
-func Test_IsRoomAvailable_OverlappingAvailable_Success(t *testing.T) {
+func Test_IsRoomAvailableForOneDay_OverlappingAvailable_Success(t *testing.T) {
 	// One interval overlaps with another, choose the least one
 	svc, _, _, _, _ := CreateTestRoomService()
 	day := time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC)
@@ -202,12 +202,12 @@ func Test_IsRoomAvailable_OverlappingAvailable_Success(t *testing.T) {
 	rules := []internal.RoomAvailabilityItem{}
 	rules = append(rules, rule1, rule2)
 
-	isAvailable := svc.IsRoomAvailable(day, rules)
+	isAvailable := svc.IsRoomAvailableForOneDay(day, rules)
 
 	assert.Equal(t, true, isAvailable)
 }
 
-func Test_IsRoomAvailable_OverlappingUnavailable_Success(t *testing.T) {
+func Test_IsRoomAvailableForOneDay_OverlappingUnavailable_Success(t *testing.T) {
 	// One interval overlaps with another, choose the least one
 	svc, _, _, _, _ := CreateTestRoomService()
 	day := time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC)
@@ -229,12 +229,12 @@ func Test_IsRoomAvailable_OverlappingUnavailable_Success(t *testing.T) {
 	rules := []internal.RoomAvailabilityItem{}
 	rules = append(rules, rule1, rule2)
 
-	isAvailable := svc.IsRoomAvailable(day, rules)
+	isAvailable := svc.IsRoomAvailableForOneDay(day, rules)
 
 	assert.Equal(t, false, isAvailable)
 }
 
-func Test_IsRoomAvailable_NoOverlappingUnavailable_Success(t *testing.T) {
+func Test_IsRoomAvailableForOneDay_NoOverlappingUnavailable_Success(t *testing.T) {
 	// For undefined day, the room is unavailable by default
 	svc, _, _, _, _ := CreateTestRoomService()
 	day := time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC)
@@ -256,12 +256,12 @@ func Test_IsRoomAvailable_NoOverlappingUnavailable_Success(t *testing.T) {
 	rules := []internal.RoomAvailabilityItem{}
 	rules = append(rules, rule1, rule2)
 
-	isAvailable := svc.IsRoomAvailable(day, rules)
+	isAvailable := svc.IsRoomAvailableForOneDay(day, rules)
 
 	assert.Equal(t, false, isAvailable)
 }
 
-func Test_CanBook_UndefinedRulesUnavailable(t *testing.T) {
+func Test_IsRoomAvailable_UndefinedRulesUnavailable(t *testing.T) {
 	svc, _, mockRepo, _, _ := CreateTestRoomService()
 	dateFrom := time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC)
 	dateTo := time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC)
@@ -269,14 +269,14 @@ func Test_CanBook_UndefinedRulesUnavailable(t *testing.T) {
 
 	mockRepo.On("FindCurrentListOfRoom", roomId).Return(nil, fmt.Errorf("room availability list not found"))
 
-	canBook := svc.CanBook(dateFrom, dateTo, roomId)
+	canBook := svc.IsRoomAvailable(dateFrom, dateTo, roomId)
 
 	assert.Equal(t, false, canBook)
 	mockRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
 	mockRepo.AssertExpectations(t)
 }
 
-func Test_CanBook_OverlappingAvailable(t *testing.T) {
+func Test_IsRoomAvailable_OverlappingAvailable(t *testing.T) {
 	svc, _, mockRepo, _, _ := CreateTestRoomService()
 	dateFrom := time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC)
 	dateTo := time.Date(2025, 8, 18, 0, 0, 0, 0, time.UTC)
@@ -303,14 +303,14 @@ func Test_CanBook_OverlappingAvailable(t *testing.T) {
 
 	mockRepo.On("FindCurrentListOfRoom", roomId).Return(&rules, nil)
 
-	canBook := svc.CanBook(dateFrom, dateTo, roomId)
+	canBook := svc.IsRoomAvailable(dateFrom, dateTo, roomId)
 
 	assert.Equal(t, true, canBook)
 	mockRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
 	mockRepo.AssertExpectations(t)
 }
 
-func Test_CanBook_OverlappingAvailableAdvanced(t *testing.T) {
+func Test_IsRoomAvailable_OverlappingAvailableAdvanced(t *testing.T) {
 	svc, _, mockRepo, _, _ := CreateTestRoomService()
 	dateFrom := time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC)
 	dateTo := time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC)
@@ -343,14 +343,14 @@ func Test_CanBook_OverlappingAvailableAdvanced(t *testing.T) {
 
 	mockRepo.On("FindCurrentListOfRoom", roomId).Return(&rules, nil)
 
-	canBook := svc.CanBook(dateFrom, dateTo, roomId)
+	canBook := svc.IsRoomAvailable(dateFrom, dateTo, roomId)
 
 	assert.Equal(t, true, canBook)
 	mockRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
 	mockRepo.AssertExpectations(t)
 }
 
-func Test_CanBook_OverlappingUnavailable(t *testing.T) {
+func Test_IsRoomAvailable_OverlappingUnavailable(t *testing.T) {
 	svc, _, mockRepo, _, _ := CreateTestRoomService()
 	dateFrom := time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC)
 	dateTo := time.Date(2025, 8, 18, 0, 0, 0, 0, time.UTC)
@@ -377,7 +377,7 @@ func Test_CanBook_OverlappingUnavailable(t *testing.T) {
 
 	mockRepo.On("FindCurrentListOfRoom", roomId).Return(&rules, nil)
 
-	canBook := svc.CanBook(dateFrom, dateTo, roomId)
+	canBook := svc.IsRoomAvailable(dateFrom, dateTo, roomId)
 
 	assert.Equal(t, false, canBook)
 	mockRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)

--- a/src/test/unit/find_available_rooms_test.go
+++ b/src/test/unit/find_available_rooms_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bookem-room-service/internal"
+	"bookem-room-service/util"
 	"fmt"
 	"testing"
 	"time"
@@ -9,30 +10,453 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_FindAvailableRooms_Success(t *testing.T) {
-	svc, mockRepo, _, _, _ := CreateTestRoomService()
+func Test_ClearYear_Success(t *testing.T) {
+	svc, _, _, _, _ := CreateTestRoomService()
 
-	room1 := DefaultRoomResult
-	room2 := DefaultRoomResult
-	room3 := DefaultRoomResult
-	info := DefaulPaginatedResultInfoDTO
-	d := *DefaultRoomsQueryDTO
+	date1 := time.Now()
+	date2 := time.Now().Add(24 * time.Hour)
 
-	rooms := []internal.RoomResultDTO{*room1, *room2, *room3}
-	var totalHits int64 = 3
+	date1Res, date2Res := svc.ClearYear(date1, date2)
 
-	mockRepo.
-		On("FindAvailableRooms", d.Location, d.GuestsNumber, d.DateFrom, d.DateTo, d.PageNumber, d.PageSize).
-		Return(rooms, totalHits, nil)
+	assert.Equal(t, date1Res.Day(), date1.Day())
+	assert.Equal(t, date1Res.Month(), date1.Month())
+	assert.NotEqual(t, date1Res.Year(), date1.Year())
+	assert.Equal(t, date2Res.Day(), date2.Day())
+	assert.Equal(t, date2Res.Month(), date2.Month())
+	assert.NotEqual(t, date2Res.Year(), date2.Year())
+}
 
-	roomsGot, infoGot, err := svc.FindAvailableRooms(d)
+func Test_CheckPrice_BasePrice_Success(t *testing.T) {
+	svc, _, _, _, _ := CreateTestRoomService()
+	day := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	day = util.ClearYear(day)
+	basePrice := uint(1000)
+	rulePrice := uint(100)
+
+	rule := internal.RoomPriceItem{
+		ID:       1,
+		DateFrom: time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		Price:    rulePrice,
+	}
+	rules := []internal.RoomPriceItem{rule}
+
+	priceRes := svc.CheckPrice(day, uint(basePrice), rules)
+
+	assert.Equal(t, basePrice, priceRes)
+}
+
+func Test_CheckPrice_DefinedPriceByRule_Success(t *testing.T) {
+	svc, _, _, _, _ := CreateTestRoomService()
+	day := time.Date(2025, 8, 13, 0, 0, 0, 0, time.UTC)
+	day = util.ClearYear(day)
+	basePrice := uint(1000)
+	rulePrice := uint(100)
+
+	rule := internal.RoomPriceItem{
+		ID:       1,
+		DateFrom: time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		Price:    rulePrice,
+	}
+	rules := []internal.RoomPriceItem{rule}
+
+	priceRes := svc.CheckPrice(day, uint(basePrice), rules)
+
+	assert.Equal(t, rulePrice, priceRes)
+}
+
+func Test_CalculatePrice_UndefinedRules_Fail(t *testing.T) {
+	svc, _, _, mockPriceRepo, _ := CreateTestRoomService()
+	dateFrom := time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 8, 25, 0, 0, 0, 0, time.UTC)
+	guestsNumber := uint(2)
+	roomId := uint(1)
+
+	mockPriceRepo.On("FindCurrentListOfRoom", roomId).Return(nil, fmt.Errorf("not found"))
+	totalPrice, perGuest, err := svc.CalculatePrice(dateFrom, dateTo, guestsNumber, roomId)
+
+	assert.Error(t, err)
+	assert.Equal(t, float32(0), totalPrice)
+	assert.Equal(t, false, perGuest)
+	mockPriceRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
+	mockPriceRepo.AssertExpectations(t)
+}
+
+func Test_CalculatePrice_PerGuest_Success(t *testing.T) {
+	svc, _, _, mockPriceRepo, _ := CreateTestRoomService()
+	dateFrom := time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 8, 24, 0, 0, 0, 0, time.UTC)
+	guestsNumber := uint(2)
+	roomId := uint(1)
+
+	var rules internal.RoomPriceList = internal.RoomPriceList{
+		ID:            1,
+		RoomID:        roomId,
+		EffectiveFrom: dateFrom,
+		BasePrice:     300,
+		PerGuest:      true,
+		Items:         []internal.RoomPriceItem{},
+	}
+	rule1 := internal.RoomPriceItem{
+		ID:       1,
+		DateFrom: time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 14, 0, 0, 0, 0, time.UTC),
+		Price:    100,
+	}
+	rule2 := internal.RoomPriceItem{
+		ID:       2,
+		DateFrom: time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 24, 0, 0, 0, 0, time.UTC),
+		Price:    200,
+	}
+	rules.Items = append(rules.Items, rule1, rule2)
+
+	mockPriceRepo.On("FindCurrentListOfRoom", roomId).Return(&rules, nil)
+	totalPrice, perGuest, err := svc.CalculatePrice(dateFrom, dateTo, guestsNumber, roomId)
 
 	assert.NoError(t, err)
-	assert.Equal(t, rooms, roomsGot)
-	assert.Equal(t, info, infoGot)
-	mockRepo.AssertNumberOfCalls(t, "FindAvailableRooms", 1)
+	// 5 x 100 x 2  +  5 x 300 x 2  +  5 x 200 x 2  =  6000
+	assert.Equal(t, float32(6000), totalPrice)
+	assert.Equal(t, true, perGuest)
+	mockPriceRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
+	mockPriceRepo.AssertExpectations(t)
+}
+
+func Test_CalculatePrice_FlatPrice_Success(t *testing.T) {
+	svc, _, _, mockPriceRepo, _ := CreateTestRoomService()
+	dateFrom := time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 8, 24, 0, 0, 0, 0, time.UTC)
+	guestsNumber := uint(2)
+	roomId := uint(1)
+
+	var rules internal.RoomPriceList = internal.RoomPriceList{
+		ID:            1,
+		RoomID:        roomId,
+		EffectiveFrom: dateFrom,
+		BasePrice:     300,
+		PerGuest:      false,
+		Items:         []internal.RoomPriceItem{},
+	}
+	rule1 := internal.RoomPriceItem{
+		ID:       1,
+		DateFrom: time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 14, 0, 0, 0, 0, time.UTC),
+		Price:    100,
+	}
+	rule2 := internal.RoomPriceItem{
+		ID:       2,
+		DateFrom: time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 24, 0, 0, 0, 0, time.UTC),
+		Price:    200,
+	}
+	rules.Items = append(rules.Items, rule1, rule2)
+
+	mockPriceRepo.On("FindCurrentListOfRoom", roomId).Return(&rules, nil)
+	totalPrice, perGuest, err := svc.CalculatePrice(dateFrom, dateTo, guestsNumber, roomId)
+
+	assert.NoError(t, err)
+	// 5 x 100  +  5 x 300  +  5 x 200  =  3000
+	assert.Equal(t, float32(3000), totalPrice)
+	assert.Equal(t, false, perGuest)
+	mockPriceRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
+	mockPriceRepo.AssertExpectations(t)
+}
+
+func Test_IsRoomAvailable_OverlappingAvailable_Success(t *testing.T) {
+	// One interval overlaps with another, choose the least one
+	svc, _, _, _, _ := CreateTestRoomService()
+	day := time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC)
+	day = util.ClearYear(day)
+
+	rule1 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		Available: false,
+	}
+	rule2 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 16, 0, 0, 0, 0, time.UTC),
+		Available: true,
+	}
+
+	rules := []internal.RoomAvailabilityItem{}
+	rules = append(rules, rule1, rule2)
+
+	isAvailable := svc.IsRoomAvailable(day, rules)
+
+	assert.Equal(t, true, isAvailable)
+}
+
+func Test_IsRoomAvailable_OverlappingUnavailable_Success(t *testing.T) {
+	// One interval overlaps with another, choose the least one
+	svc, _, _, _, _ := CreateTestRoomService()
+	day := time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC)
+	day = util.ClearYear(day)
+
+	rule1 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		Available: true,
+	}
+	rule2 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 16, 0, 0, 0, 0, time.UTC),
+		Available: false,
+	}
+
+	rules := []internal.RoomAvailabilityItem{}
+	rules = append(rules, rule1, rule2)
+
+	isAvailable := svc.IsRoomAvailable(day, rules)
+
+	assert.Equal(t, false, isAvailable)
+}
+
+func Test_IsRoomAvailable_NoOverlappingUnavailable_Success(t *testing.T) {
+	// For undefined day, the room is unavailable by default
+	svc, _, _, _, _ := CreateTestRoomService()
+	day := time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC)
+	day = util.ClearYear(day)
+
+	rule1 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		Available: true,
+	}
+	rule2 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 16, 0, 0, 0, 0, time.UTC),
+		Available: false,
+	}
+
+	rules := []internal.RoomAvailabilityItem{}
+	rules = append(rules, rule1, rule2)
+
+	isAvailable := svc.IsRoomAvailable(day, rules)
+
+	assert.Equal(t, false, isAvailable)
+}
+
+func Test_CanBook_UndefinedRulesUnavailable(t *testing.T) {
+	svc, _, mockRepo, _, _ := CreateTestRoomService()
+	dateFrom := time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC)
+	roomId := uint(1)
+
+	mockRepo.On("FindCurrentListOfRoom", roomId).Return(nil, fmt.Errorf("room availability list not found"))
+
+	canBook := svc.CanBook(dateFrom, dateTo, roomId)
+
+	assert.Equal(t, false, canBook)
+	mockRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
 	mockRepo.AssertExpectations(t)
 }
+
+func Test_CanBook_OverlappingAvailable(t *testing.T) {
+	svc, _, mockRepo, _, _ := CreateTestRoomService()
+	dateFrom := time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 8, 18, 0, 0, 0, 0, time.UTC)
+	roomId := uint(1)
+
+	var rules internal.RoomAvailabilityList = internal.RoomAvailabilityList{
+		ID:     1,
+		RoomID: roomId,
+		Items:  []internal.RoomAvailabilityItem{},
+	}
+	rule1 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 30, 0, 0, 0, 0, time.UTC),
+		Available: false,
+	}
+	rule2 := internal.RoomAvailabilityItem{
+		ID:        2,
+		DateFrom:  time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		Available: true,
+	}
+	rules.Items = append(rules.Items, rule1, rule2)
+
+	mockRepo.On("FindCurrentListOfRoom", roomId).Return(&rules, nil)
+
+	canBook := svc.CanBook(dateFrom, dateTo, roomId)
+
+	assert.Equal(t, true, canBook)
+	mockRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_CanBook_OverlappingAvailableAdvanced(t *testing.T) {
+	svc, _, mockRepo, _, _ := CreateTestRoomService()
+	dateFrom := time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC)
+	roomId := uint(1)
+
+	var rules internal.RoomAvailabilityList = internal.RoomAvailabilityList{
+		ID:     1,
+		RoomID: roomId,
+		Items:  []internal.RoomAvailabilityItem{},
+	}
+	rule1 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 30, 0, 0, 0, 0, time.UTC),
+		Available: false,
+	}
+	rule2 := internal.RoomAvailabilityItem{
+		ID:        2,
+		DateFrom:  time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		Available: true,
+	}
+	rule3 := internal.RoomAvailabilityItem{
+		ID:        3,
+		DateFrom:  time.Date(2025, 8, 16, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		Available: true,
+	}
+	rules.Items = append(rules.Items, rule1, rule2, rule3)
+
+	mockRepo.On("FindCurrentListOfRoom", roomId).Return(&rules, nil)
+
+	canBook := svc.CanBook(dateFrom, dateTo, roomId)
+
+	assert.Equal(t, true, canBook)
+	mockRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_CanBook_OverlappingUnavailable(t *testing.T) {
+	svc, _, mockRepo, _, _ := CreateTestRoomService()
+	dateFrom := time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 8, 18, 0, 0, 0, 0, time.UTC)
+	roomId := uint(1)
+
+	var rules internal.RoomAvailabilityList = internal.RoomAvailabilityList{
+		ID:     1,
+		RoomID: roomId,
+		Items:  []internal.RoomAvailabilityItem{},
+	}
+	rule1 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 30, 0, 0, 0, 0, time.UTC),
+		Available: true,
+	}
+	rule2 := internal.RoomAvailabilityItem{
+		ID:        2,
+		DateFrom:  time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		Available: false,
+	}
+	rules.Items = append(rules.Items, rule1, rule2)
+
+	mockRepo.On("FindCurrentListOfRoom", roomId).Return(&rules, nil)
+
+	canBook := svc.CanBook(dateFrom, dateTo, roomId)
+
+	assert.Equal(t, false, canBook)
+	mockRepo.AssertNumberOfCalls(t, "FindCurrentListOfRoom", 1)
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_CalculateUnitPricePerGuest(t *testing.T) {
+	svc, _, _, _, _ := CreateTestRoomService()
+	perGuest := true
+	guestsNumber := uint(2)
+	dateFrom := time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 8, 19, 0, 0, 0, 0, time.UTC)
+	totalPrice := float32(10000)
+
+	unitPrice := svc.CalculateUnitPrice(perGuest, guestsNumber, dateFrom, dateTo, totalPrice)
+
+	// 10000 / 10 / 2  =  500
+	assert.Equal(t, float32(500), unitPrice)
+}
+
+func Test_CalculateUnitPriceFlat(t *testing.T) {
+	svc, _, _, _, _ := CreateTestRoomService()
+	perGuest := false
+	guestsNumber := uint(99)
+	dateFrom := time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 8, 19, 0, 0, 0, 0, time.UTC)
+	totalPrice := float32(10000)
+
+	unitPrice := svc.CalculateUnitPrice(perGuest, guestsNumber, dateFrom, dateTo, totalPrice)
+
+	// 10000 / 10  =  1000
+	assert.Equal(t, float32(1000), unitPrice)
+}
+
+func Test_PreparePaginatedResult_Success(t *testing.T) {
+	svc, _, _, _, _ := CreateTestRoomService()
+
+	pageNumber := uint(1)
+	pageSize := uint(10)
+	hits := []internal.RoomResultDTO{}
+	for i := 0; i < 50; i++ {
+		hits = append(hits, *DefaultRoomResult)
+	}
+
+	hitsResult, resultInfo := svc.PreparePaginatedResult(hits, pageNumber, pageSize)
+
+	assert.Equal(t, pageNumber, resultInfo.Page)
+	assert.Equal(t, pageSize, resultInfo.PageSize)
+	assert.Equal(t, uint(5), resultInfo.TotalPages)
+	assert.Equal(t, uint(50), resultInfo.TotalHits)
+	assert.Equal(t, int(10), len(hitsResult))
+}
+
+func Test_PreparePaginatedResult_OutOfMargin(t *testing.T) {
+	// Show last page result if page number exceeds total
+	svc, _, _, _, _ := CreateTestRoomService()
+
+	pageNumber := uint(99999)
+	pageSize := uint(10)
+	hits := []internal.RoomResultDTO{}
+	for i := 0; i < 15; i++ {
+		hits = append(hits, *DefaultRoomResult)
+	}
+
+	hitsResult, resultInfo := svc.PreparePaginatedResult(hits, pageNumber, pageSize)
+
+	assert.Equal(t, pageNumber, resultInfo.Page)
+	assert.Equal(t, pageSize, resultInfo.PageSize)
+	assert.Equal(t, pageSize, resultInfo.PageSize)
+	assert.Equal(t, uint(2), resultInfo.TotalPages)
+	assert.Equal(t, uint(15), resultInfo.TotalHits)
+	assert.Equal(t, int(5), len(hitsResult))
+}
+
+func Test_PreparePaginatedResult_LastPage(t *testing.T) {
+	// Case when the last page is selected
+	svc, _, _, _, _ := CreateTestRoomService()
+
+	pageNumber := uint(2)
+	pageSize := uint(10)
+	hits := []internal.RoomResultDTO{}
+	for i := 0; i < 15; i++ {
+		hits = append(hits, *DefaultRoomResult)
+	}
+
+	hitsResult, resultInfo := svc.PreparePaginatedResult(hits, pageNumber, pageSize)
+
+	assert.Equal(t, pageNumber, resultInfo.Page)
+	assert.Equal(t, pageSize, resultInfo.PageSize)
+	assert.Equal(t, pageSize, resultInfo.PageSize)
+	assert.Equal(t, uint(2), resultInfo.TotalPages)
+	assert.Equal(t, uint(15), resultInfo.TotalHits)
+	assert.Equal(t, int(5), len(hitsResult))
+}
+
+// ---------------------------------------------------- OLD
 
 func Test_FindAvailableRooms_InvalidDate(t *testing.T) {
 	svc, mockRepo, _, _, _ := CreateTestRoomService()
@@ -45,7 +469,7 @@ func Test_FindAvailableRooms_InvalidDate(t *testing.T) {
 	assert.Nil(t, roomsGot)
 	assert.Nil(t, infoGot)
 	assert.Error(t, err)
-	mockRepo.AssertNumberOfCalls(t, "FindAvailableRooms", 0)
+	mockRepo.AssertNumberOfCalls(t, "FindByFilters", 0)
 	mockRepo.AssertExpectations(t)
 }
 
@@ -54,15 +478,202 @@ func Test_FindAvailableRooms_DbError(t *testing.T) {
 
 	d := *DefaultRoomsQueryDTO
 
-	mockRepo.
-		On("FindAvailableRooms", d.Location, d.GuestsNumber, d.DateFrom, d.DateTo, d.PageNumber, d.PageSize).
-		Return(nil, nil, fmt.Errorf("db error"))
+	mockRepo.On("FindByFilters", d.GuestsNumber, d.Address).Return(nil, fmt.Errorf("db error"))
 
 	roomsGot, infoGot, err := svc.FindAvailableRooms(d)
 
 	assert.Nil(t, roomsGot)
 	assert.Nil(t, infoGot)
 	assert.Error(t, err)
-	mockRepo.AssertNumberOfCalls(t, "FindAvailableRooms", 1)
+	mockRepo.AssertNumberOfCalls(t, "FindByFilters", 1)
+	mockRepo.AssertExpectations(t)
+}
+
+func Test_FindAvailableRooms_Success(t *testing.T) {
+	svc, mockRepo, mockAvailRepo, mockPriceRepo, _ := CreateTestRoomService()
+
+	rooms := []internal.Room{}
+	room1 := internal.Room{
+		ID:        1,
+		HostID:    1,
+		Name:      "room1",
+		Address:   "address1",
+		MinGuests: 2,
+		MaxGuests: 5,
+	}
+	room2 := internal.Room{
+		ID:        2,
+		HostID:    2,
+		Name:      "room2",
+		Address:   "address2",
+		MinGuests: 1,
+		MaxGuests: 4,
+	}
+	rooms = append(rooms, room1, room2)
+
+	// room availability rules
+	var availRules1 internal.RoomAvailabilityList = internal.RoomAvailabilityList{
+		ID:     1,
+		RoomID: room1.ID,
+		Items:  []internal.RoomAvailabilityItem{},
+	}
+	rule1 := internal.RoomAvailabilityItem{
+		ID:        1,
+		DateFrom:  time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 30, 0, 0, 0, 0, time.UTC),
+		Available: false,
+	}
+	rule2 := internal.RoomAvailabilityItem{
+		ID:        2,
+		DateFrom:  time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		Available: true,
+	}
+	availRules1.Items = append(availRules1.Items, rule1, rule2)
+
+	var availRules2 internal.RoomAvailabilityList = internal.RoomAvailabilityList{
+		ID:     2,
+		RoomID: room2.ID,
+		Items:  []internal.RoomAvailabilityItem{},
+	}
+	rule1 = internal.RoomAvailabilityItem{
+		ID:        3,
+		DateFrom:  time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 5, 0, 0, 0, 0, time.UTC),
+		Available: false,
+	}
+	rule2 = internal.RoomAvailabilityItem{
+		ID:        4,
+		DateFrom:  time.Date(2025, 8, 6, 0, 0, 0, 0, time.UTC),
+		DateTo:    time.Date(2025, 8, 30, 0, 0, 0, 0, time.UTC),
+		Available: true,
+	}
+	availRules2.Items = append(availRules2.Items, rule1, rule2)
+
+	// price rules
+	var priceRules1 internal.RoomPriceList = internal.RoomPriceList{
+		ID:            1,
+		RoomID:        room1.ID,
+		EffectiveFrom: time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		BasePrice:     300,
+		PerGuest:      true,
+		Items:         []internal.RoomPriceItem{},
+	}
+	priceRule1 := internal.RoomPriceItem{
+		ID:       1,
+		DateFrom: time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		Price:    100,
+	}
+	priceRule2 := internal.RoomPriceItem{
+		ID:       2,
+		DateFrom: time.Date(2025, 8, 16, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 30, 0, 0, 0, 0, time.UTC),
+		Price:    200,
+	}
+	priceRules1.Items = append(priceRules1.Items, priceRule1, priceRule2)
+
+	var priceRules2 internal.RoomPriceList = internal.RoomPriceList{
+		ID:            2,
+		RoomID:        room2.ID,
+		EffectiveFrom: time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		BasePrice:     500,
+		PerGuest:      false,
+		Items:         []internal.RoomPriceItem{},
+	}
+	priceRule1 = internal.RoomPriceItem{
+		ID:       3,
+		DateFrom: time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 15, 0, 0, 0, 0, time.UTC),
+		Price:    400,
+	}
+	priceRule2 = internal.RoomPriceItem{
+		ID:       4,
+		DateFrom: time.Date(2025, 8, 16, 0, 0, 0, 0, time.UTC),
+		DateTo:   time.Date(2025, 8, 30, 0, 0, 0, 0, time.UTC),
+		Price:    600,
+	}
+	priceRules2.Items = append(priceRules2.Items, priceRule1, priceRule2)
+
+	query := internal.RoomsQueryDTO{
+		Address:      "address",
+		GuestsNumber: 3,
+		DateFrom:     time.Date(2025, 8, 10, 0, 0, 0, 0, time.UTC),
+		DateTo:       time.Date(2025, 8, 20, 0, 0, 0, 0, time.UTC),
+		PageNumber:   1,
+		PageSize:     1,
+	}
+
+	// [1] none address
+	query.Address = "none"
+	mockRepo.On("FindByFilters", query.GuestsNumber, query.Address).Return(nil, nil)
+
+	roomsGot, infoGot, err := svc.FindAvailableRooms(query)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(roomsGot))
+	assert.Equal(t, query.PageNumber, infoGot.Page)
+	assert.Equal(t, query.PageSize, infoGot.PageSize)
+	assert.Equal(t, uint(0), infoGot.TotalHits)
+	assert.Equal(t, uint(0), infoGot.TotalPages)
+	mockRepo.AssertNumberOfCalls(t, "FindByFilters", 1)
+	mockRepo.AssertExpectations(t)
+
+	// [2] testing pagination
+	query.PageNumber = uint(5)
+	query.PageSize = uint(2)
+	query.Address = "none"
+	mockRepo.On("FindByFilters", query.GuestsNumber, query.Address).Return(nil, nil)
+
+	roomsGot, infoGot, err = svc.FindAvailableRooms(query)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(roomsGot))
+	assert.Equal(t, query.PageNumber, infoGot.Page)
+	assert.Equal(t, query.PageSize, infoGot.PageSize)
+	assert.Equal(t, uint(0), infoGot.TotalHits)
+	assert.Equal(t, uint(0), infoGot.TotalPages)
+	mockRepo.AssertNumberOfCalls(t, "FindByFilters", 2)
+	mockRepo.AssertExpectations(t)
+
+	// [3] Both rooms are available
+	query.PageSize = 1
+	query.PageNumber = 1
+	query.Address = "address"
+	mockRepo.On("FindByFilters", query.GuestsNumber, query.Address).Return(rooms, nil)
+	mockAvailRepo.On("FindCurrentListOfRoom", room1.ID).Return(&availRules1, nil)
+	mockAvailRepo.On("FindCurrentListOfRoom", room2.ID).Return(&availRules2, nil)
+	mockPriceRepo.On("FindCurrentListOfRoom", room1.ID).Return(&priceRules1, nil)
+	mockPriceRepo.On("FindCurrentListOfRoom", room2.ID).Return(&priceRules2, nil)
+
+	roomsGot, infoGot, err = svc.FindAvailableRooms(query)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(roomsGot))
+	assert.Equal(t, uint(2), infoGot.TotalHits)
+	assert.Equal(t, query.PageSize, infoGot.PageSize)
+	assert.Equal(t, uint(2), infoGot.TotalPages)
+	mockRepo.AssertNumberOfCalls(t, "FindByFilters", 3)
+	mockRepo.AssertExpectations(t)
+
+	// [4] Single room is available
+	query.PageSize = 4
+	query.PageNumber = 1
+	query.DateFrom = time.Date(2025, 8, 6, 0, 0, 0, 0, time.UTC)
+	query.DateTo = time.Date(2025, 8, 7, 0, 0, 0, 0, time.UTC)
+	mockRepo.On("FindByFilters", query.GuestsNumber, query.Address).Return(rooms, nil)
+	mockAvailRepo.On("FindCurrentListOfRoom", room1.ID).Return(&availRules1, nil)
+	mockAvailRepo.On("FindCurrentListOfRoom", room2.ID).Return(&availRules2, nil)
+	mockPriceRepo.On("FindCurrentListOfRoom", room1.ID).Return(&priceRules1, nil)
+	mockPriceRepo.On("FindCurrentListOfRoom", room2.ID).Return(&priceRules2, nil)
+
+	roomsGot, infoGot, err = svc.FindAvailableRooms(query)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(roomsGot))
+	assert.Equal(t, uint(1), infoGot.TotalHits)
+	assert.Equal(t, query.PageSize, infoGot.PageSize)
+	assert.Equal(t, uint(1), infoGot.TotalPages)
+	mockRepo.AssertNumberOfCalls(t, "FindByFilters", 4)
 	mockRepo.AssertExpectations(t)
 }

--- a/src/test/unit/util.go
+++ b/src/test/unit/util.go
@@ -57,6 +57,13 @@ func (r *MockRoomRepo) FindByHost(hostId uint) ([]internal.Room, error) {
 	return user, args.Error(1)
 }
 
+func (r *MockRoomRepo) FindAvailableRooms(location string, hostId uint, dateFrom time.Time, dateTo time.Time, minGuests uint, maxGuests uint) ([]internal.RoomResultDTO, int64, error) {
+	args := r.Called(location, hostId, dateFrom, dateTo, minGuests, maxGuests)
+	rooms, _ := args.Get(0).([]internal.RoomResultDTO)
+	total, _ := args.Get(1).(int64)
+	return rooms, total, args.Error(2)
+}
+
 // ----------------------------------------------- Mock room availabilty repo
 
 type MockRoomAvailabilityRepo struct {
@@ -267,4 +274,30 @@ var DefaultCreatePriceItemDTO = internal.CreateRoomPriceItemDTO{
 var DefaultCreatePriceListDTO = internal.CreateRoomPriceListDTO{
 	RoomID: DefaultRoom.ID,
 	Items:  []internal.CreateRoomPriceItemDTO{DefaultCreatePriceItemDTO},
+}
+
+var DefaultRoomsQueryDTO = &internal.RoomsQueryDTO{
+	Location:     "location",
+	GuestsNumber: 4,
+	DateFrom:     time.Date(2025, 8, 6, 0, 0, 0, 0, time.UTC),
+	DateTo:       time.Date(2025, 8, 7, 0, 0, 0, 0, time.UTC),
+	PageNumber:   1,
+	PageSize:     10,
+}
+
+var DefaultRoomResult = &internal.RoomResultDTO{
+	ID:          1,
+	Name:        "Room Name",
+	Description: "Room Desc",
+	Address:     "Room Address",
+	Photos:      []string{"test.png"},
+	BasePrice:   100.0,
+	TotalPrice:  200.0,
+}
+
+var DefaulPaginatedResultInfoDTO = &internal.PaginatedResultInfoDTO{
+	Page:       1,
+	PageSize:   10,
+	TotalPages: 1,
+	TotalHits:  3,
 }

--- a/src/test/unit/util.go
+++ b/src/test/unit/util.go
@@ -57,11 +57,10 @@ func (r *MockRoomRepo) FindByHost(hostId uint) ([]internal.Room, error) {
 	return user, args.Error(1)
 }
 
-func (r *MockRoomRepo) FindAvailableRooms(location string, hostId uint, dateFrom time.Time, dateTo time.Time, minGuests uint, maxGuests uint) ([]internal.RoomResultDTO, int64, error) {
-	args := r.Called(location, hostId, dateFrom, dateTo, minGuests, maxGuests)
-	rooms, _ := args.Get(0).([]internal.RoomResultDTO)
-	total, _ := args.Get(1).(int64)
-	return rooms, total, args.Error(2)
+func (r *MockRoomRepo) FindByFilters(guestsNumber uint, location string) ([]internal.Room, error) {
+	args := r.Called(uint(guestsNumber), string(location))
+	rooms, _ := args.Get(0).([]internal.Room)
+	return rooms, args.Error(1)
 }
 
 // ----------------------------------------------- Mock room availabilty repo
@@ -277,7 +276,7 @@ var DefaultCreatePriceListDTO = internal.CreateRoomPriceListDTO{
 }
 
 var DefaultRoomsQueryDTO = &internal.RoomsQueryDTO{
-	Location:     "location",
+	Address:      "address",
 	GuestsNumber: 4,
 	DateFrom:     time.Date(2025, 8, 6, 0, 0, 0, 0, time.UTC),
 	DateTo:       time.Date(2025, 8, 7, 0, 0, 0, 0, time.UTC),
@@ -291,7 +290,7 @@ var DefaultRoomResult = &internal.RoomResultDTO{
 	Description: "Room Desc",
 	Address:     "Room Address",
 	Photos:      []string{"test.png"},
-	BasePrice:   100.0,
+	UnitPrice:   100.0,
 	TotalPrice:  200.0,
 }
 


### PR DESCRIPTION
Closes: #6, #13.

_Caveat:_ I will add front-end support for this function in the coming days. I just want to finish merging with `develop` since these changes are related to the test directory structure.

For simplicity, since this is primarily a search function, I implemented most of the logic in SQL. As I lost the ability to write plenty of unit tests, I enforced the use of integration tests to ensure the quality of the implemented feature. All in all, I won’t be doing something like this again, as there are many drawbacks to this approach.

Introducing `main_test.go` will help us control the content of the DBs in each test, which is a prerequisite for some features. I haven't found an easier way under the current setup than doing this. An alternative would be using [Testcontainers](https://testcontainers.com/). The same logic can be applied to other microservices if there is demand in the future. All you would need to do is call `cleanup(service_name)` inside your integration test in order to truncate the content of all tables.

____
### Test parallel execution issue

__For instance:__
The integration method `CreateRoom` was causing multiple rooms to be created. I spent hours trying to identify the cause of the following error, with no success. If you try to add `fmt.Printf` for printing the `ID` of the `host` and `room`, you will see that during the first test, `TestIntegration_Create_Success`, the `CreateRoom` handler somehow gets triggered three times. I don’t understand why this is happening.

__Update:__
The behavior was very messy and difficult to debug. In Go, all tests within the same package run sequentially [more about](https://bryce.is/writing/code/go-test-and-parallelism). However, parallelism is handled at the package level. Therefore, the inconsistent behavior was caused by executing tests in parallel (thread concurrency). Since we had different packages (availability, price, and integration), they were recognized by the Go testing module as separate, even though they were all pointing to the same test package.

__Solution:__
- There is no support to explicitly run a test sequentially (https://github.com/golang/go/issues/61318). 
- Other solutions, like creating additional database schemas, are not efficient enough. 
- Introducing resource identifiers for each test where this matters seems like overkill.
- Chosen solution: Make sure all tests are within the same package. Tests are a little slower (volatile behavior), but this has been a good enough solution for now.

Currently, all tests run sequentially. If we want to speed things up, we can use the Testing.parallel directive for each test that can be run in parallel.

_There may be even better options, but I didn’t dig that deep since the current solution seems to work for now._
